### PR TITLE
Add Availability Annotations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,9 +6,9 @@ import PackageDescription
 let package = Package(
     name: "stable-diffusion",
     platforms: [
-        .macOS(.v13),
-        .iOS(.v16),
-       ],
+        .macOS(.v11),
+        .iOS(.v14),
+    ],
     products: [
         .library(
             name: "StableDiffusion",

--- a/swift/StableDiffusion/pipeline/Decoder.swift
+++ b/swift/StableDiffusion/pipeline/Decoder.swift
@@ -6,6 +6,7 @@ import CoreML
 import Accelerate
 
 /// A decoder model which produces RGB images from latent samples
+@available(iOS 16.2, macOS 13.1, *)
 public struct Decoder: ResourceManaging {
 
     /// VAE decoder model

--- a/swift/StableDiffusion/pipeline/ManagedMLModel.swift
+++ b/swift/StableDiffusion/pipeline/ManagedMLModel.swift
@@ -7,6 +7,7 @@ import CoreML
 ///
 /// It will automatically load a model into memory when needed or requested
 /// It allows one to request to unload the model from memory
+@available(iOS 16.2, macOS 13.1, *)
 public final class ManagedMLModel: ResourceManaging {
 
     /// The location of the model

--- a/swift/StableDiffusion/pipeline/Random.swift
+++ b/swift/StableDiffusion/pipeline/Random.swift
@@ -9,6 +9,7 @@ import CoreML
 ///  This implementation matches:
 ///  [NumPy's older randomkit.c](https://github.com/numpy/numpy/blob/v1.0/numpy/random/mtrand/randomkit.c)
 ///
+@available(iOS 16.2, macOS 13.1, *)
 struct NumPyRandomSource: RandomNumberGenerator {
 
     struct State {

--- a/swift/StableDiffusion/pipeline/SafetyChecker.swift
+++ b/swift/StableDiffusion/pipeline/SafetyChecker.swift
@@ -6,6 +6,7 @@ import CoreML
 import Accelerate
 
 /// Image safety checking model
+@available(iOS 16.2, macOS 13.1, *)
 public struct SafetyChecker: ResourceManaging {
 
     /// Safety checking Core ML model

--- a/swift/StableDiffusion/pipeline/SampleTimer.swift
+++ b/swift/StableDiffusion/pipeline/SampleTimer.swift
@@ -18,6 +18,7 @@ import Foundation
 /// print(String(format: "mean: %.2f, var: %.2f",
 ///              timer.mean, timer.variance))
 /// ```
+@available(iOS 16.2, macOS 13.1, *)
 public final class SampleTimer: Codable {
     var startTime: CFAbsoluteTime?
     var sum: Double = 0.0

--- a/swift/StableDiffusion/pipeline/Scheduler.swift
+++ b/swift/StableDiffusion/pipeline/Scheduler.swift
@@ -9,6 +9,7 @@ import CoreML
 ///  [Hugging Face Diffusers PNDMScheduler](https://github.com/huggingface/diffusers/blob/main/src/diffusers/schedulers/scheduling_pndm.py)
 ///
 /// It uses the pseudo linear multi-step (PLMS) method only, skipping pseudo Runge-Kutta (PRK) steps
+@available(iOS 16.2, macOS 13.1, *)
 public final class Scheduler {
     /// Number of diffusion steps performed during training
     public let trainStepCount: Int
@@ -224,6 +225,7 @@ public final class Scheduler {
     }
 }
 
+@available(iOS 16.2, macOS 13.1, *)
 extension Scheduler {
     /// How to map a beta range to a sequence of betas to step over
     public enum BetaSchedule {

--- a/swift/StableDiffusion/pipeline/StableDiffusionPipeline+Resources.swift
+++ b/swift/StableDiffusion/pipeline/StableDiffusionPipeline+Resources.swift
@@ -4,6 +4,7 @@
 import Foundation
 import CoreML
 
+@available(iOS 16.2, macOS 13.1, *)
 public extension StableDiffusionPipeline {
 
     struct ResourceURLs {

--- a/swift/StableDiffusion/pipeline/StableDiffusionPipeline.swift
+++ b/swift/StableDiffusion/pipeline/StableDiffusionPipeline.swift
@@ -10,6 +10,7 @@ import CoreGraphics
 ///
 /// This implementation matches:
 /// [Hugging Face Diffusers Pipeline](https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py)
+@available(iOS 16.2, macOS 13.1, *)
 public struct StableDiffusionPipeline: ResourceManaging {
 
     /// Model to generate embeddings for tokenized input text
@@ -271,6 +272,7 @@ public struct StableDiffusionPipeline: ResourceManaging {
 
 }
 
+@available(iOS 16.2, macOS 13.1, *)
 extension StableDiffusionPipeline {
     /// Sampling progress details
     public struct Progress {

--- a/swift/StableDiffusion/pipeline/TextEncoder.swift
+++ b/swift/StableDiffusion/pipeline/TextEncoder.swift
@@ -5,6 +5,7 @@ import Foundation
 import CoreML
 
 ///  A model for encoding text
+@available(iOS 16.2, macOS 13.1, *)
 public struct TextEncoder: ResourceManaging {
 
     /// Text tokenizer

--- a/swift/StableDiffusion/pipeline/Unet.swift
+++ b/swift/StableDiffusion/pipeline/Unet.swift
@@ -5,6 +5,7 @@ import Foundation
 import CoreML
 
 /// U-Net noise prediction model for stable diffusion
+@available(iOS 16.2, macOS 13.1, *)
 public struct Unet: ResourceManaging {
 
     /// Model used to predict noise residuals given an input, diffusion time step, and conditional embedding

--- a/swift/StableDiffusion/tokenizer/BPETokenizer+Reading.swift
+++ b/swift/StableDiffusion/tokenizer/BPETokenizer+Reading.swift
@@ -3,6 +3,7 @@
 
 import Foundation
 
+@available(iOS 16.2, macOS 13.1, *)
 extension BPETokenizer {
     enum FileReadError: Error {
         case invalidMergeFileLine(Int)

--- a/swift/StableDiffusion/tokenizer/BPETokenizer.swift
+++ b/swift/StableDiffusion/tokenizer/BPETokenizer.swift
@@ -4,6 +4,7 @@
 import Foundation
 
 /// A tokenizer based on byte pair encoding.
+@available(iOS 16.2, macOS 13.1, *)
 public struct BPETokenizer {
     /// A dictionary that maps pairs of tokens to the rank/order of the merge.
     let merges: [TokenPair : Int]
@@ -166,6 +167,7 @@ public struct BPETokenizer {
     }
 }
 
+@available(iOS 16.2, macOS 13.1, *)
 extension BPETokenizer {
 
     /// A hashable tuple of strings

--- a/swift/StableDiffusionCLI/main.swift
+++ b/swift/StableDiffusionCLI/main.swift
@@ -8,6 +8,7 @@ import Foundation
 import StableDiffusion
 import UniformTypeIdentifiers
 
+@available(iOS 16.2, macOS 13.1, *)
 struct StableDiffusionSample: ParsableCommand {
 
     static let configuration = CommandConfiguration(
@@ -176,6 +177,7 @@ enum RunError: Error {
     case saving(String)
 }
 
+@available(iOS 16.2, macOS 13.1, *)
 enum ComputeUnits: String, ExpressibleByArgument, CaseIterable {
     case all, cpuAndGPU, cpuOnly, cpuAndNeuralEngine
     var asMLComputeUnits: MLComputeUnits {
@@ -188,4 +190,8 @@ enum ComputeUnits: String, ExpressibleByArgument, CaseIterable {
     }
 }
 
-StableDiffusionSample.main()
+if #available(iOS 16.2, macOS 13.1, *) {
+    StableDiffusionSample.main()
+} else {
+    print("Unsupported OS")
+}

--- a/swift/StableDiffusionTests/StableDiffusionTests.swift
+++ b/swift/StableDiffusionTests/StableDiffusionTests.swift
@@ -5,6 +5,7 @@ import XCTest
 import CoreML
 @testable import StableDiffusion
 
+@available(iOS 16.2, macOS 13.1, *)
 final class StableDiffusionTests: XCTestCase {
 
     var vocabFileInBundleURL: URL {


### PR DESCRIPTION
- Add availability annotations rather than limiting package availability to iOS 16 / macOS 12. This is necessary for anyone who wants to incorporate this package in an existing app that needs to support older platforms, since weak linking a Swift package is not possible.