### PR TITLE
Image2image

### DIFF
--- a/python_coreml_stable_diffusion/torch2coreml.py
+++ b/python_coreml_stable_diffusion/torch2coreml.py
@@ -10,6 +10,7 @@ from collections import OrderedDict, defaultdict
 from copy import deepcopy
 import coremltools as ct
 from diffusers import StableDiffusionPipeline
+from diffusers.models.vae import DiagonalGaussianDistribution
 import gc
 
 import logging
@@ -29,10 +30,21 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+#from coremltools.converters.mil.frontend.torch.torch_op_registry import register_torch_op
+#from coremltools.converters.mil.frontend.torch.ops import _get_inputs
+#from coremltools.converters.mil import Builder as mb
+#
+#@register_torch_op
+#def randn(context, node):
+#    inputs = _get_inputs(context, node, expected=5)
+#    shape = inputs[0]
+#
+#    x = mb.random_normal(shape=shape, mean=0., stddev=1.)
+#    context.add(x, node.name)
+
 torch.set_grad_enabled(False)
 
 from types import MethodType
-
 
 def _get_coreml_inputs(sample_inputs, args):
     return [
@@ -534,6 +546,7 @@ def convert_vae_encoder(pipe, args):
             h = self.encoder(sample)
             moments = self.quant_conv(h)
             diagonalNoise = diagonalNoise.to(sample.device)
+#            posterior = DiagonalGaussianDistribution(moments)
             posterior = CoreMLDiagonalGaussianDistribution(moments, diagonalNoise)
             posteriorSample = posterior.sample()
             

--- a/swift/StableDiffusion/pipeline/AlphasCumprodCalculation.swift
+++ b/swift/StableDiffusion/pipeline/AlphasCumprodCalculation.swift
@@ -1,0 +1,29 @@
+// For licensing see accompanying LICENSE.md file.
+// Copyright (C) 2022 Apple Inc. All Rights Reserved.
+
+import Foundation
+
+public struct AlphasCumprodCalculation {
+    public var sqrtAlphasCumprod: Float
+    public var sqrtOneMinusAlphasCumprod: Float
+    
+    public init(
+        sqrtAlphasCumprod: Float,
+        sqrtOneMinusAlphasCumprod: Float
+    ) {
+        self.sqrtAlphasCumprod = sqrtAlphasCumprod
+        self.sqrtOneMinusAlphasCumprod = sqrtOneMinusAlphasCumprod
+    }
+    
+    public init(
+        alphasCumprod: [Float],
+        timesteps: Int = 1_000,
+        steps: Int,
+        strength: Float
+    ) {
+        let tEnc = Int(strength * Float(steps))
+        let initTimestep = timesteps - timesteps / steps * (steps - tEnc) + 1
+        self.sqrtAlphasCumprod = alphasCumprod[initTimestep].squareRoot()
+        self.sqrtOneMinusAlphasCumprod = (1 - alphasCumprod[initTimestep]).squareRoot()
+    }
+}

--- a/swift/StableDiffusion/pipeline/AlphasCumprodCalculation.swift
+++ b/swift/StableDiffusion/pipeline/AlphasCumprodCalculation.swift
@@ -22,7 +22,7 @@ public struct AlphasCumprodCalculation {
         strength: Float
     ) {
         let tEnc = Int(strength * Float(steps))
-        let initTimestep = timesteps - timesteps / steps * (steps - tEnc) + 1
+        let initTimestep = min(max(0, timesteps - timesteps / steps * (steps - tEnc) + 1), timesteps - 1)
         self.sqrtAlphasCumprod = alphasCumprod[initTimestep].squareRoot()
         self.sqrtOneMinusAlphasCumprod = (1 - alphasCumprod[initTimestep]).squareRoot()
     }

--- a/swift/StableDiffusion/pipeline/CGImage+vImage.swift
+++ b/swift/StableDiffusion/pipeline/CGImage+vImage.swift
@@ -1,0 +1,120 @@
+// For licensing see accompanying LICENSE.md file.
+// Copyright (C) 2022 Apple Inc. All Rights Reserved.
+
+import Foundation
+import Accelerate
+import CoreML
+
+@available(iOS 16.0, macOS 13.0, *)
+extension CGImage {
+    
+    typealias PixelBufferPFx1 = vImage.PixelBuffer<vImage.PlanarF>
+    typealias PixelBufferP8x3 = vImage.PixelBuffer<vImage.Planar8x3>
+    typealias PixelBufferIFx3 = vImage.PixelBuffer<vImage.InterleavedFx3>
+    typealias PixelBufferI8x3 = vImage.PixelBuffer<vImage.Interleaved8x3>
+    
+    public enum ShapedArrayError: String, Swift.Error {
+        case wrongNumberOfChannels
+        case incorrectFormatsConvertingToShapedArray
+        case vImageConverterNotInitialized
+    }
+    
+    public static func fromShapedArray(_ array: MLShapedArray<Float32>) throws -> CGImage {
+        
+        // array is [N,C,H,W], where C==3
+        let channelCount = array.shape[1]
+        guard channelCount == 3 else {
+            throw ShapedArrayError.wrongNumberOfChannels
+        }
+        
+        let height = array.shape[2]
+        let width = array.shape[3]
+
+        // Normalize each channel into a float between 0 and 1.0
+        let floatChannels = (0..<channelCount).map { i in
+
+            // Normalized channel output
+            let cOut = PixelBufferPFx1(width: width, height:height)
+
+            // Reference this channel in the array and normalize
+            array[0][i].withUnsafeShapedBufferPointer { ptr, _, strides in
+                let cIn = PixelBufferPFx1(data: .init(mutating: ptr.baseAddress!),
+                                          width: width, height: height,
+                                          byteCountPerRow: strides[0]*4)
+                // Map [-1.0 1.0] -> [0.0 1.0]
+                cIn.multiply(by: 0.5, preBias: 1.0, postBias: 0.0, destination: cOut)
+            }
+            return cOut
+        }
+
+        // Convert to interleaved and then to UInt8
+        let floatImage = PixelBufferIFx3(planarBuffers: floatChannels)
+        let uint8Image = PixelBufferI8x3(width: width, height: height)
+        floatImage.convert(to:uint8Image) // maps [0.0 1.0] -> [0 255] and clips
+
+        // Convert to uint8x3 to RGB CGImage (no alpha)
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.none.rawValue)
+        let cgImage = uint8Image.makeCGImage(cgImageFormat:
+                .init(bitsPerComponent: 8,
+                      bitsPerPixel: 3*8,
+                      colorSpace: CGColorSpaceCreateDeviceRGB(),
+                      bitmapInfo: bitmapInfo)!)!
+
+        return cgImage
+    }
+    
+    public var plannerRGBShapedArray: MLShapedArray<Float32> {
+        get throws {
+            guard
+                var sourceFormat = vImage_CGImageFormat(cgImage: self),
+                var mediumFormat = vImage_CGImageFormat(
+                    bitsPerComponent: 8 * MemoryLayout<UInt8>.size,
+                    bitsPerPixel: 8 * MemoryLayout<UInt8>.size * 4,
+                    colorSpace: CGColorSpaceCreateDeviceRGB(),
+                    bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.first.rawValue)),
+                let width = vImagePixelCount(exactly: self.width),
+                let height = vImagePixelCount(exactly: self.height)
+            else {
+                throw ShapedArrayError.incorrectFormatsConvertingToShapedArray
+            }
+            
+            var sourceImageBuffer = try vImage_Buffer(cgImage: self)
+            
+            var mediumDesination = try vImage_Buffer(width: Int(width), height: Int(height), bitsPerPixel: mediumFormat.bitsPerPixel)
+            
+            let converter = vImageConverter_CreateWithCGImageFormat(
+                &sourceFormat,
+                &mediumFormat,
+                nil,
+                vImage_Flags(kvImagePrintDiagnosticsToConsole),
+                nil)
+            
+            guard let converter = converter?.takeRetainedValue() else {
+                throw ShapedArrayError.vImageConverterNotInitialized
+            }
+            
+            vImageConvert_AnyToAny(converter, &sourceImageBuffer, &mediumDesination, nil, vImage_Flags(kvImagePrintDiagnosticsToConsole))
+            
+            var destinationA = try vImage_Buffer(width: Int(width), height: Int(height), bitsPerPixel: 8 * UInt32(MemoryLayout<Float>.size))
+            var destinationR = try vImage_Buffer(width: Int(width), height: Int(height), bitsPerPixel: 8 * UInt32(MemoryLayout<Float>.size))
+            var destinationG = try vImage_Buffer(width: Int(width), height: Int(height), bitsPerPixel: 8 * UInt32(MemoryLayout<Float>.size))
+            var destinationB = try vImage_Buffer(width: Int(width), height: Int(height), bitsPerPixel: 8 * UInt32(MemoryLayout<Float>.size))
+            
+            var minFloat: [Float] = [-1.0, -1.0, -1.0, -1.0]
+            var maxFloat: [Float] = [1.0, 1.0, 1.0, 1.0]
+            
+            vImageConvert_ARGB8888toPlanarF(&mediumDesination, &destinationA, &destinationR, &destinationG, &destinationB, &maxFloat, &minFloat, .zero)
+           
+            let redData = Data(bytes: destinationR.data, count: Int(width) * Int(height) * MemoryLayout<Float>.size)
+            let greenData = Data(bytes: destinationG.data, count: Int(width) * Int(height) * MemoryLayout<Float>.size)
+            let blueData = Data(bytes: destinationB.data, count: Int(width) * Int(height) * MemoryLayout<Float>.size)
+            
+            let imageData = redData + greenData + blueData
+
+            let shapedArray = MLShapedArray<Float32>(data: imageData, shape: [1, 3, 512, 512])
+            
+            return shapedArray
+        }
+    }
+}
+

--- a/swift/StableDiffusion/pipeline/DPMSolverMultistepScheduler.swift
+++ b/swift/StableDiffusion/pipeline/DPMSolverMultistepScheduler.swift
@@ -23,15 +23,11 @@ public final class DPMSolverMultistepScheduler: Scheduler {
     public let betas: [Float]
     public let alphas: [Float]
     public let alphasCumProd: [Float]
-    private let timeSteps: [Int]
+    public let timeSteps: [Int]
 
     public let alpha_t: [Float]
     public let sigma_t: [Float]
     public let lambda_t: [Float]
-    
-    public var allTimeSteps: [Int] {
-        timeSteps
-    }
     
     public let solverOrder = 2
     private(set) var lowerOrderStepped = 0
@@ -182,5 +178,10 @@ public final class DPMSolverMultistepScheduler: Scheduler {
         }
         
         return prevSample
+    }
+    
+    /// This scheduler does not support image2image strength value.
+    public func calculateTimesteps(strength: Float?) -> [Int] {
+        timeSteps
     }
 }

--- a/swift/StableDiffusion/pipeline/DPMSolverMultistepScheduler.swift
+++ b/swift/StableDiffusion/pipeline/DPMSolverMultistepScheduler.swift
@@ -178,10 +178,5 @@ public final class DPMSolverMultistepScheduler: Scheduler {
         }
         
         return prevSample
-    }
-    
-    /// This scheduler does not support image2image strength value.
-    public func calculateTimesteps(strength: Float?) -> [Int] {
-        timeSteps
-    }
+    }    
 }

--- a/swift/StableDiffusion/pipeline/DPMSolverMultistepScheduler.swift
+++ b/swift/StableDiffusion/pipeline/DPMSolverMultistepScheduler.swift
@@ -23,11 +23,15 @@ public final class DPMSolverMultistepScheduler: Scheduler {
     public let betas: [Float]
     public let alphas: [Float]
     public let alphasCumProd: [Float]
-    public let timeSteps: [Int]
+    private let timeSteps: [Int]
 
     public let alpha_t: [Float]
     public let sigma_t: [Float]
     public let lambda_t: [Float]
+    
+    public var allTimeSteps: [Int] {
+        timeSteps
+    }
     
     public let solverOrder = 2
     private(set) var lowerOrderStepped = 0

--- a/swift/StableDiffusion/pipeline/Encoder.swift
+++ b/swift/StableDiffusion/pipeline/Encoder.swift
@@ -1,0 +1,80 @@
+// For licensing see accompanying LICENSE.md file.
+// Copyright (C) 2022 Apple Inc. All Rights Reserved.
+
+import Foundation
+import CoreML
+
+@available(iOS 16.0, macOS 13.0, *)
+/// Encoder, currently supports image2image
+public struct Encoder {
+    
+    public enum Error: String, Swift.Error {
+        case latentOutputNotValid
+        case batchLatentOutputEmpty
+    }
+    
+    /// VAE encoder model + post math and adding noise from schedular
+    var model: MLModel
+    
+    /// Create decoder from Core ML model
+    ///
+    /// - Parameters
+    ///     - model: Core ML model for VAE decoder
+    public init(model: MLModel) {
+        self.model = model
+    }
+    
+    /// Prediction queue
+    let queue = DispatchQueue(label: "encoder.predict")
+
+    /// Batch encode latent samples into images
+    /// - Parameters:
+    ///   - image: image used for image2image
+    ///   - diagonalNoise: random noise for `DiagonalGaussianDistribution` operation
+    ///   - noise: random noise for initial latent space based on strength argument
+    ///   - alphasCumprodStep: calculations using the scheduler traditionally calculated in the pipeline in pyTorch Diffusers library.
+    /// - Returns: The encoded latent space as MLShapedArray
+    public func encode(
+        image:  CGImage,
+        diagonalNoise: MLShapedArray<Float32>,
+        noise: MLShapedArray<Float32>,
+        alphasCumprodStep: AlphasCumprodCalculation
+    ) throws -> MLShapedArray<Float32> {
+        let sample = try image.plannerRGBShapedArray
+        let sqrtAlphasCumprod = MLShapedArray(scalars: [alphasCumprodStep.sqrtAlphasCumprod], shape: [1, 1])
+        let sqrtOneMinusAlphasCumprod = MLShapedArray(scalars: [alphasCumprodStep.sqrtOneMinusAlphasCumprod], shape: [1, 1])
+        
+        let dict: [String: Any] = [
+            "sample": MLMultiArray(sample),
+            "diagonalNoise": MLMultiArray(diagonalNoise),
+            "noise": MLMultiArray(noise),
+            "sqrtAlphasCumprod": MLMultiArray(sqrtAlphasCumprod),
+            "sqrtOneMinusAlphasCumprod": MLMultiArray(sqrtOneMinusAlphasCumprod),
+        ]
+        let featureProvider = try MLDictionaryFeatureProvider(dictionary: dict)
+        
+        let batch = MLArrayBatchProvider(array: [featureProvider])
+
+        // Batch predict with model
+        let results = try queue.sync { try model.predictions(fromBatch: batch) }
+        
+        let batchLatents: [MLShapedArray<Float32>] = try (0..<results.count).compactMap { i in
+            let result = results.features(at: i)
+            guard
+                let outputName = result.featureNames.first,
+                let output = result.featureValue(for: outputName)?.multiArrayValue
+            else {
+                throw Error.latentOutputNotValid
+            }
+            print("output.shape: \(output.shape)")
+            return MLShapedArray(output)
+        }
+        
+        guard let latents = batchLatents.first else {
+            throw Error.batchLatentOutputEmpty
+        }
+        
+        return latents
+    }
+    
+}

--- a/swift/StableDiffusion/pipeline/Encoder.swift
+++ b/swift/StableDiffusion/pipeline/Encoder.swift
@@ -66,7 +66,6 @@ public struct Encoder {
             else {
                 throw Error.latentOutputNotValid
             }
-            print("output.shape: \(output.shape)")
             return MLShapedArray(output)
         }
         

--- a/swift/StableDiffusion/pipeline/Scheduler.swift
+++ b/swift/StableDiffusion/pipeline/Scheduler.swift
@@ -12,7 +12,7 @@ public protocol Scheduler {
     var inferenceStepCount: Int { get }
     
     /// Training diffusion time steps index by inference time step
-    var allTimeSteps: [Int] { get }
+    var timeSteps: [Int] { get }
 
     /// Training diffusion time steps index by inference time step
     func calculateTimesteps(strength: Float?) -> [Int]
@@ -94,9 +94,9 @@ public extension Scheduler {
 public extension Scheduler {
     
     func calculateTimesteps(strength: Float?) -> [Int] {
-        guard let strength else { return allTimeSteps.reversed() }
+        guard let strength else { return timeSteps.reversed() }
         let startStep = Int(Float(inferenceStepCount) * strength)
-        let acutalTimesteps = Array(allTimeSteps[0..<startStep].reversed())
+        let acutalTimesteps = Array(timeSteps[0..<startStep].reversed())
         return acutalTimesteps
     }
 }
@@ -127,11 +127,7 @@ public final class PNDMScheduler: Scheduler {
     public let betas: [Float]
     public let alphas: [Float]
     public let alphasCumProd: [Float]
-    private let timeSteps: [Int]
-    
-    public var allTimeSteps: [Int] {
-        timeSteps
-    }
+    public let timeSteps: [Int]
 
     // Internal state
     var counter: Int

--- a/swift/StableDiffusion/pipeline/Scheduler.swift
+++ b/swift/StableDiffusion/pipeline/Scheduler.swift
@@ -92,12 +92,11 @@ public extension Scheduler {
 
 @available(iOS 16.2, macOS 13.1, *)
 public extension Scheduler {
-    
     func calculateTimesteps(strength: Float?) -> [Int] {
-        guard let strength else { return timeSteps.reversed() }
-        let startStep = Int(Float(inferenceStepCount) * strength)
-        let acutalTimesteps = Array(timeSteps[0..<startStep].reversed())
-        return acutalTimesteps
+        guard let strength else { return timeSteps }
+        let startStep = max(inferenceStepCount - Int(Float(inferenceStepCount) * strength), 0)
+        let actualTimesteps = Array(timeSteps[startStep...])
+        return actualTimesteps
     }
 }
 
@@ -175,7 +174,7 @@ public final class PNDMScheduler: Scheduler {
         timeSteps.append(contentsOf: forwardSteps.dropLast(1))
         timeSteps.append(timeSteps.last!)
         timeSteps.append(forwardSteps.last!)
-        // do no revers timeSteps, this is now done in `calculateTimesteps` function
+        timeSteps.reverse()
 
         self.timeSteps = timeSteps
         self.counter = 0

--- a/swift/StableDiffusion/pipeline/Scheduler.swift
+++ b/swift/StableDiffusion/pipeline/Scheduler.swift
@@ -179,7 +179,7 @@ public final class PNDMScheduler: Scheduler {
         timeSteps.append(contentsOf: forwardSteps.dropLast(1))
         timeSteps.append(timeSteps.last!)
         timeSteps.append(forwardSteps.last!)
-        timeSteps.reverse()
+        // do no revers timeSteps, this is now done in `calculateTimesteps` function
 
         self.timeSteps = timeSteps
         self.counter = 0

--- a/swift/StableDiffusion/pipeline/StableDiffusionPipeline+Resources.swift
+++ b/swift/StableDiffusion/pipeline/StableDiffusionPipeline+Resources.swift
@@ -14,6 +14,7 @@ public extension StableDiffusionPipeline {
         public let unetChunk1URL: URL
         public let unetChunk2URL: URL
         public let decoderURL: URL
+        public let encoderURL: URL
         public let safetyCheckerURL: URL
         public let vocabURL: URL
         public let mergesURL: URL
@@ -24,6 +25,7 @@ public extension StableDiffusionPipeline {
             unetChunk1URL = baseURL.appending(path: "UnetChunk1.mlmodelc")
             unetChunk2URL = baseURL.appending(path: "UnetChunk2.mlmodelc")
             decoderURL = baseURL.appending(path: "VAEDecoder.mlmodelc")
+            encoderURL = baseURL.appending(path: "VAEEncoder.mlmodelc")
             safetyCheckerURL = baseURL.appending(path: "SafetyChecker.mlmodelc")
             vocabURL = baseURL.appending(path: "vocab.json")
             mergesURL = baseURL.appending(path: "merges.txt")
@@ -74,11 +76,22 @@ public extension StableDiffusionPipeline {
             FileManager.default.fileExists(atPath: urls.safetyCheckerURL.path) {
             safetyChecker = SafetyChecker(modelAt: urls.safetyCheckerURL, configuration: config)
         }
+        
+        // Optional Image Encoder
+        let encoder: Encoder?
+        if
+            let encoderModel = try? MLModel(contentsOf: urls.encoderURL, configuration: config)
+        {
+            encoder = Encoder(model: encoderModel)
+        } else {
+            encoder = nil
+        }
 
         // Construct pipeline
         self.init(textEncoder: textEncoder,
                   unet: unet,
                   decoder: decoder,
+                  encoder: encoder,
                   safetyChecker: safetyChecker,
                   reduceMemory: reduceMemory)
     }

--- a/swift/StableDiffusion/pipeline/StableDiffusionPipeline.swift
+++ b/swift/StableDiffusion/pipeline/StableDiffusionPipeline.swift
@@ -219,7 +219,7 @@ public struct StableDiffusionPipeline: ResourceManaging {
                 pipeline: self,
                 prompt: prompt,
                 step: step,
-                stepCount: stepCount,
+                stepCount: timeSteps.count,
                 currentLatentSamples: latents,
                 isSafetyEnabled: canSafetyCheck && !disableSafety
             )

--- a/swift/StableDiffusion/pipeline/StableDiffusionPipeline.swift
+++ b/swift/StableDiffusion/pipeline/StableDiffusionPipeline.swift
@@ -258,7 +258,7 @@ public struct StableDiffusionPipeline: ResourceManaging {
     ///   - diagonalAndLatentNoiseIsSame: Diffusions library does not seem to use the same noise for the `DiagonalGaussianDistribution` operation,
     ///     but I have seen implementations of pipelines where it is the same.
     /// - Returns: An array of tuples of noise values with length of batch size.
-    func generateImage2ImageLatentSamples(_ count: Int, stdev: Float, seed: Int, diagonalAndLatentNoiseIsSame: Bool = false) -> [(diagonal: MLShapedArray<Float32>, latentNoise: MLShapedArray<Float32>)] {
+    func generateImage2ImageLatentSamples(_ count: Int, stdev: Float, seed: UInt32, diagonalAndLatentNoiseIsSame: Bool = false) -> [(diagonal: MLShapedArray<Float32>, latentNoise: MLShapedArray<Float32>)] {
         var sampleShape = unet.latentSampleShape
         sampleShape[0] = 1
 

--- a/swift/StableDiffusion/pipeline/StableDiffusionPipeline.swift
+++ b/swift/StableDiffusion/pipeline/StableDiffusionPipeline.swift
@@ -23,7 +23,6 @@ public struct StableDiffusionPipeline: ResourceManaging {
     
     public enum Error: String, Swift.Error {
         case startingImageProvidedWithoutEncoder
-        case schedulerNotSupportedWithImage2Image
     }
 
     /// Model to generate embeddings for tokenized input text
@@ -169,12 +168,6 @@ public struct StableDiffusionPipeline: ResourceManaging {
             timestepStrength = strength
             guard let encoder else {
                 throw Error.startingImageProvidedWithoutEncoder
-            }
-            switch schedulerType {
-            case .pndmScheduler:
-                break
-            case .dpmSolverMultistepScheduler:
-                throw Error.schedulerNotSupportedWithImage2Image
             }
             
             let noiseTuples = generateImage2ImageLatentSamples(imageCount, stdev: 1, seed: seed)

--- a/swift/StableDiffusionCLI/main.swift
+++ b/swift/StableDiffusionCLI/main.swift
@@ -94,9 +94,6 @@ struct StableDiffusionSample: ParsableCommand {
         let startingImage: CGImage?
         if image != "none" {
             let imageURL = URL(filePath: image)
-//            if FileManager.default.fileExists(atPath: imageURL.path()) {
-//                throw RunError.resources("Starting image not found \(imageURL)")
-//            }
             do {
                 let imageData = try Data(contentsOf: imageURL)
                 guard


### PR DESCRIPTION
Adds image2image functionality.

In Python, a new CoreML model can be generated to encode the latent space for image2image. The model bakes in some of the operations typically performed in the pipeline so that a separate model would not need to be created for those operations, now would the CPU be needed to perform the tensor multiplications. Some of the simpler math involving the scheduler's time steps are performed on the cpu and  passed into the encoder. The encoder works around `torch.randn` missing operation by passing in nose tensors to apply to the image latent space.

In Swift, an Encoder class is created. Various changes to the scheduler, pipeline, and CLI to support input image and strength. CGImage creation from MLShapedArray is moved into it's own file along with the new function to create a MLShapedArray from a CGImage. Image loading and preparation is currently handled / optimized with vImage. 

Understandable a desire to maybe use the Image Input type for CoreML / CoreMLTools, however, I chose not to optimize in this way at this at this point because of trouble that I have had getting enumerated input shapes to work with the models and current python script. Please see: [#69](https://github.com/apple/ml-stable-diffusion/issues/69) and [#70](https://github.com/apple/ml-stable-diffusion/issues/70).

The new `DPMSolverMultistepScheduler` does not work with image2image, and looking at the Diffusers library documentation, it does not look like it is supported there either, so, it is currently disabled and should throw an error. Though I also made it safe so it will not crash..

Thank you for providing this repo.

Do not erase the below when submitting your pull request:
#########

- [x] I agree to the terms outlined in CONTRIBUTING.md 
