### PR TITLE
Make `--negative-prompt` optional

### DIFF
--- a/swift/StableDiffusionCLI/main.swift
+++ b/swift/StableDiffusionCLI/main.swift
@@ -20,7 +20,7 @@ struct StableDiffusionSample: ParsableCommand {
     var prompt: String
 
     @Option(help: "Input string negative prompt")
-    var negativePrompt: String
+    var negativePrompt: String = ""
 
     @Option(
         help: ArgumentHelp(


### PR DESCRIPTION
The negative prompt has been introduced in #61 as an additional mean to influence the image generation.
The default value of `negativePrompt` in `generateImages` is "" and should therefore be the same when using the CLI tool.

This is fixed with this commit.

#########

- [x] I agree to the terms outlined in CONTRIBUTING.md 
