### PR TITLE
Fix number of downsample channels

### DIFF
--- a/python_coreml_stable_diffusion/unet.py
+++ b/python_coreml_stable_diffusion/unet.py
@@ -376,7 +376,7 @@ class CrossAttnDownBlock2D(nn.Module):
         self.resnets = nn.ModuleList(resnets)
 
         if add_downsample:
-            self.downsamplers = nn.ModuleList([Downsample2D(in_channels)])
+            self.downsamplers = nn.ModuleList([Downsample2D(out_channels)])
         else:
             self.downsamplers = None
 


### PR DESCRIPTION
Reference: https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/unet_2d_blocks.py#L749-L756

This is usually not a problem for Stable Diffusion models. However, some architectures such as
https://huggingface.co/OFA-Sys/small-stable-diffusion-v0 wouldn't convert.

----

Thank you for your interest in contributing to Core ML Stable Diffusion! Please review [CONTRIBUTING.md](../CONTRIBUTING.md) first. If you would like to proceed with making a pull request, please indicate your agreement to the terms outlined in CONTRIBUTING.md by checking the box below. If not, please go ahead and fork this repo and make your updates.

We appreciate your interest in the project!

Do not erase the below when submitting your pull request:
#########

- [x] I agree to the terms outlined in CONTRIBUTING.md 
