### PR TITLE
Fix torch version warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coremltools
 diffusers[torch]
-torch
+torch == 1.12.1
 transformers
 scipy

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     install_requires=[
         "coremltools>=6.1",
         "diffusers[torch]",
-        "torch",
+        "torch==1.12.1",
         "transformers",
         "scipy",
         "numpy<1.24",


### PR DESCRIPTION
```
Torch version 1.13.1 has not been tested with coremltools. You may run into unexpected errors. Torch 1.12.1 is the most recent version that has been tested.
```

- [x] I agree to the terms outlined in CONTRIBUTING.md 