### PR TITLE
Image2image - python

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ pip install -e .
 **Step 4:** Execute the following command from the Terminal to generate Core ML model files (`.mlpackage`)
 
 ```shell
-python -m python_coreml_stable_diffusion.torch2coreml --convert-unet --convert-text-encoder --convert-vae-decoder --convert-safety-checker -o <output-mlpackages-directory>
+python -m python_coreml_stable_diffusion.torch2coreml --convert-unet --convert-text-encoder --convert-vae-decoder  --convert-vae-encoder --convert-safety-checker -o <output-mlpackages-directory>
 ```
 
 **WARNING:** This command will download several GB worth of PyTorch checkpoints from Hugging Face. Please ensure that you are on Wi-Fi and have enough disk space.
@@ -219,6 +219,10 @@ Both of these products require the Core ML models and tokenization resources to 
 - `VAEDecoder.mlmodelc` (image decoder model)
 - `vocab.json` (tokenizer vocabulary file)
 - `merges.text` (merges for byte pair encoding file)
+
+Optionally, for image2image, in-painting, or similar:
+
+- `VAEEnecoder.mlmodelc` (image encoder model) 
 
 Optionally, it may also include the safety checker model that some versions of Stable Diffusion include:
 
@@ -321,6 +325,7 @@ Differences may be less or more pronounced for different inputs. Please see the 
 <b> A3: </b>  In order to minimize the memory impact of the model conversion process, please execute the following command instead:
 
 ```bash
+python -m python_coreml_stable_diffusion.torch2coreml --convert-vae-encoder -o <output-mlpackages-directory> && \
 python -m python_coreml_stable_diffusion.torch2coreml --convert-vae-decoder -o <output-mlpackages-directory> && \
 python -m python_coreml_stable_diffusion.torch2coreml --convert-unet -o <output-mlpackages-directory> && \
 python -m python_coreml_stable_diffusion.torch2coreml --convert-text-encoder -o <output-mlpackages-directory> && \

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ pip install -e .
 **Step 4:** Execute the following command from the Terminal to generate Core ML model files (`.mlpackage`)
 
 ```shell
-python -m python_coreml_stable_diffusion.torch2coreml --convert-unet --convert-text-encoder --convert-vae-decoder  --convert-vae-encoder --convert-safety-checker -o <output-mlpackages-directory>
+python -m python_coreml_stable_diffusion.torch2coreml --convert-unet --convert-text-encoder --convert-vae-decoder --convert-safety-checker -o <output-mlpackages-directory>
 ```
 
 **WARNING:** This command will download several GB worth of PyTorch checkpoints from Hugging Face. Please ensure that you are on Wi-Fi and have enough disk space.
@@ -222,7 +222,7 @@ Both of these products require the Core ML models and tokenization resources to 
 
 Optionally, for image2image, in-painting, or similar:
 
-- `VAEEnecoder.mlmodelc` (image encoder model) 
+- `VAEEncoder.mlmodelc` (image encoder model) 
 
 Optionally, it may also include the safety checker model that some versions of Stable Diffusion include:
 

--- a/python_coreml_stable_diffusion/torch2coreml.py
+++ b/python_coreml_stable_diffusion/torch2coreml.py
@@ -10,7 +10,6 @@ from collections import OrderedDict, defaultdict
 from copy import deepcopy
 import coremltools as ct
 from diffusers import StableDiffusionPipeline
-from diffusers.models.vae import DiagonalGaussianDistribution
 import gc
 
 import logging
@@ -30,21 +29,10 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-#from coremltools.converters.mil.frontend.torch.torch_op_registry import register_torch_op
-#from coremltools.converters.mil.frontend.torch.ops import _get_inputs
-#from coremltools.converters.mil import Builder as mb
-#
-#@register_torch_op
-#def randn(context, node):
-#    inputs = _get_inputs(context, node, expected=5)
-#    shape = inputs[0]
-#
-#    x = mb.random_normal(shape=shape, mean=0., stddev=1.)
-#    context.add(x, node.name)
-
 torch.set_grad_enabled(False)
 
 from types import MethodType
+
 
 def _get_coreml_inputs(sample_inputs, args):
     return [
@@ -546,7 +534,6 @@ def convert_vae_encoder(pipe, args):
             h = self.encoder(sample)
             moments = self.quant_conv(h)
             diagonalNoise = diagonalNoise.to(sample.device)
-#            posterior = DiagonalGaussianDistribution(moments)
             posterior = CoreMLDiagonalGaussianDistribution(moments, diagonalNoise)
             posteriorSample = posterior.sample()
             

--- a/python_coreml_stable_diffusion/torch2coreml.py
+++ b/python_coreml_stable_diffusion/torch2coreml.py
@@ -10,6 +10,7 @@ from collections import OrderedDict, defaultdict
 from copy import deepcopy
 import coremltools as ct
 from diffusers import StableDiffusionPipeline
+from diffusers.models.vae import DiagonalGaussianDistribution
 import gc
 
 import logging
@@ -29,10 +30,21 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+#from coremltools.converters.mil.frontend.torch.torch_op_registry import register_torch_op
+#from coremltools.converters.mil.frontend.torch.ops import _get_inputs
+#from coremltools.converters.mil import Builder as mb
+#
+#@register_torch_op
+#def randn(context, node):
+#    inputs = _get_inputs(context, node, expected=5)
+#    shape = inputs[0]
+#
+#    x = mb.random_normal(shape=shape, mean=0., stddev=1.)
+#    context.add(x, node.name)
+
 torch.set_grad_enabled(False)
 
 from types import MethodType
-
 
 def _get_coreml_inputs(sample_inputs, args):
     return [
@@ -534,6 +546,7 @@ def convert_vae_encoder(pipe, args):
             h = self.encoder(sample)
             moments = self.quant_conv(h)
             diagonalNoise = diagonalNoise.to(sample.device)
+#            posterior = DiagonalGaussianDistribution(moments)
             posterior = CoreMLDiagonalGaussianDistribution(moments, diagonalNoise)
             posteriorSample = posterior.sample()
             


### PR DESCRIPTION
**Adds image2image functionality.**

This is only the python portion needed to generate the VAE Encoder.

[Swift](https://github.com/apple/ml-stable-diffusion/pull/116)
[Original PR](https://github.com/apple/ml-stable-diffusion/pull/73)

In Python, a new CoreML model can be generated to encode the latent space for image2image. The model bakes in some of the operations typically performed in the pipeline so that a separate model would not need to be created for those operations, nor would the CPU be needed to perform the tensor multiplications. Some of the simpler math involving the scheduler's time steps are performed on the cpu and passed into the encoder. The encoder works around torch.randn missing operation by passing in nose tensors to apply to the image latent space.

Initial feedback from the initial PR https://github.com/apple/ml-stable-diffusion/pull/73 was to separate the python portion of the PR. Additionally, it was asked if we could implement the methodology to override the `randn` PyTorch function as instructions can be found how to do so in _coremltools_ documentation. Initially, I had no qualms digging into this task to see how we could simplify the interface. However, when investigating the issue, I had discovered that I had already tried these steps initially when I initially had encountered the missing `randn` function. I had actually implemented the suggestion from @atiorh to encounter other errors:

The initial error: 
```
  File "/opt/homebrew/Caskroom/miniforge/base/envs/coreml_stable_diffusion/lib/python3.8/site-packages/coremltools/converters/mil/frontend/torch/converter.py", line 270, in convert
    convert_nodes(self.context, self.graph)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/coreml_stable_diffusion/lib/python3.8/site-packages/coremltools/converters/mil/frontend/torch/ops.py", line 100, in convert_nodes
    raise RuntimeError(
RuntimeError: PyTorch convert function for op 'randn' not implemented.
```

Error with `randn` override:
```
  File "/opt/homebrew/Caskroom/miniforge/base/envs/coreml_stable_diffusion/lib/python3.8/site-packages/coremltools/converters/mil/frontend/torch/torch_op_registry.py", line 42, in func_wrapper
    raise ValueError("Torch op {} already registered.".format(f_name))
ValueError: Torch op randn already registered.
```

Furthermore, I cannot say that I actually agree that it is a good idea to generate the random numbers in python anyways. The  noise for the latent space generation for regular prompt based generation is generated in Swift on the CPU. It could be that some techniques might need to use the same seed. For instance, there is experimentation with interoperable translation between two latent spaces. For reasons such as this, I would weigh on the side of generating the noise from swift.

That said, in the commit history of this branch, you can see where I tried to do this a second time. Where I tried importing the original DiagonalGaussianDistribution function and overriding the `randn` function.

However, this solution copies the parts of the `DiagonalGaussianDistribution` class needed to a `CoreMLDiagonalGaussianDistribution`. Furthermore it optimizes the other operations that happen just after the VAEEncoder in the Diffusion library. Otherwise we would need yet another model, or math library to perform these routines.

Do not erase the below when submitting your pull request:
#########

- [x] I agree to the terms outlined in CONTRIBUTING.md 
