### PR TITLE
Fix Torch and Numpy runtime compatibility error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 coremltools
 diffusers[torch]
-torch
+torch==1.12.1
+numpy==1.23.1
 transformers
 scipy


### PR DESCRIPTION
Fix runtime error with latest Torch and Numpy versions

```
ml-stable-diffusion/venv/lib/python3.10/site-packages/numpy/__init__.py", line 284, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'bool'. Did you mean: 'bool_'?

Also Torch version 1.13.1 has not been tested with coremltools.
```

Thank you for your interest in contributing to Core ML Stable Diffusion! Please review [CONTRIBUTING.md](../CONTRIBUTING.md) first. If you would like to proceed with making a pull request, please indicate your agreement to the terms outlined in CONTRIBUTING.md by checking the box below. If not, please go ahead and fork this repo and make your updates.

We appreciate your interest in the project!

Do not erase the below when submitting your pull request:
#########

- [x] I agree to the terms outlined in CONTRIBUTING.md 
