### PR TITLE
Fix: Missing a nil check at StableDiffusionCLI

### DIFF
--- a/swift/StableDiffusionCLI/main.swift
+++ b/swift/StableDiffusionCLI/main.swift
@@ -205,7 +205,7 @@ struct StableDiffusionSample: ParsableCommand {
             name += ".\(sample)"
         }
         
-        if image != "none" {
+        if image != nil {
             name += ".str\(Int(strength * 100))"
         }
 


### PR DESCRIPTION
I noticed that generating images with Swift using the example prompt caused the output image to always carry the suffix `.str50`.

Looking at the code I saw that `image != "none"` was never evaluating to _**false**_.

I believe there was a small confusion between Python's `None` and Swift's `nil` representation of null. 

This super small PR fixes it.

#########

- [x] I agree to the terms outlined in CONTRIBUTING.md 
