### PR TITLE
Fix img2img starting image shape

### DIFF
--- a/swift/StableDiffusion/pipeline/CGImage+vImage.swift
+++ b/swift/StableDiffusion/pipeline/CGImage+vImage.swift
@@ -111,7 +111,7 @@ extension CGImage {
             
             let imageData = redData + greenData + blueData
 
-            let shapedArray = MLShapedArray<Float32>(data: imageData, shape: [1, 3, self.width, self.height])
+            let shapedArray = MLShapedArray<Float32>(data: imageData, shape: [1, 3, self.height, self.width])
             
             return shapedArray
     }


### PR DESCRIPTION
Fixes #140 and fixes #143.

After reading the discussion at https://github.com/godly-devotion/MochiDiffusion/issues/208 and experimenting locally, I found that swapping the width and height is enough to get img2img working with non-square resolutions. Squares are obviously unaffected by this change 🙂

EDIT: I've received feedback that this change also fixes ControlNet for these resolutions.

- [x] I agree to the terms outlined in CONTRIBUTING.md 
