### PR TITLE
Verify ControlNet base model

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "diffusers[torch]",
         "torch",
         "transformers",
+        "huggingface-hub",
         "scipy",
         "numpy<1.24",
     ],


### PR DESCRIPTION
We currently display a warning if the ControlNet repo does not contain a `base_model` property and the `model-version` is not SD 1.5.

If the ControlNet repo does indicate a `base_model` property, then we raise a hard error if the versions don't match. As an alternative, we could simply skip the mismatched models so conversion can potentially finalize for other ControlNet models in the same invocation.

We could also override `args.model_version` using the information retrieved from `base_model`, but given that multiple ControlNet models can be specified we'd need to do a first pass and verify that they were all trained from the same base model. I think overriding could make sense if the user does not specify `model-version` in the command line, but it's harder to swallow if they do.

----

Thank you for your interest in contributing to Core ML Stable Diffusion! Please review [CONTRIBUTING.md](../CONTRIBUTING.md) first. If you would like to proceed with making a pull request, please indicate your agreement to the terms outlined in CONTRIBUTING.md by checking the box below. If not, please go ahead and fork this repo and make your updates.

We appreciate your interest in the project!

Do not erase the below when submitting your pull request:
#########

- [x] I agree to the terms outlined in CONTRIBUTING.md 
