### PR TITLE
Disable SDPA (PyTorch 2.0) in the VAE

### DIFF
--- a/python_coreml_stable_diffusion/torch2coreml.py
+++ b/python_coreml_stable_diffusion/torch2coreml.py
@@ -438,7 +438,7 @@ def convert_vae_decoder(pipe, args):
             super().__init__()
             self.post_quant_conv = pipe.vae.post_quant_conv
             self.decoder = pipe.vae.decoder
-            # Disable torch 2.0 scaled dot product attention until it's supported by coremltools
+            # Disable torch 2.0 scaled dot-product attention: https://github.com/apple/coremltools/issues/1823
             self.decoder.mid_block.attentions[0]._use_2_0_attn = False
 
         def forward(self, z):

--- a/python_coreml_stable_diffusion/torch2coreml.py
+++ b/python_coreml_stable_diffusion/torch2coreml.py
@@ -438,6 +438,8 @@ def convert_vae_decoder(pipe, args):
             super().__init__()
             self.post_quant_conv = pipe.vae.post_quant_conv
             self.decoder = pipe.vae.decoder
+            # Disable torch 2.0 scaled dot product attention until it's supported by coremltools
+            self.decoder.mid_block.attentions[0]._use_2_0_attn = False
 
         def forward(self, z):
             return self.decoder(self.post_quant_conv(z))


### PR DESCRIPTION
Diffusers 0.16.0 made sdpa enabled by default in the vae. It had previously been enabled for the UNet, but of course that didn't affect this repo because it uses its own copy of the UNet.

This fix will not work for diffusers 0.16.0, but it will for `0.16.1` (just released today).

Fixes #173.

---


Thank you for your interest in contributing to Core ML Stable Diffusion! Please review [CONTRIBUTING.md](../CONTRIBUTING.md) first. If you would like to proceed with making a pull request, please indicate your agreement to the terms outlined in CONTRIBUTING.md by checking the box below. If not, please go ahead and fork this repo and make your updates.

We appreciate your interest in the project!

Do not erase the below when submitting your pull request:
#########

- [x] I agree to the terms outlined in CONTRIBUTING.md 
