### PR TITLE
Show error message when an old VAE encoder is used

### DIFF
--- a/swift/StableDiffusion/pipeline/Encoder.swift
+++ b/swift/StableDiffusion/pipeline/Encoder.swift
@@ -93,7 +93,20 @@ public struct Encoder: ResourceManaging {
     
     var inputDescription: MLFeatureDescription {
         try! model.perform { model in
-            model.modelDescription.inputDescriptionsByName["z"]!
+            guard let zInputDescription = model.modelDescription.inputDescriptionsByName["z"] else {
+                let modelVersion = model.modelDescription.metadata[MLModelMetadataKey.versionString] ?? "unknown version"
+                fatalError(
+                    """
+                    
+                    The VAE encoder of this model (\(modelVersion)) is not compatible \
+                    with this version of `ml-stable-diffusion`. Please, convert the VAE encoder again using the latest \
+                    version of this package and following the instructions here: \
+                    https://github.com/apple/ml-stable-diffusion#-converting-models-to-core-ml
+                    We'd appreciate if you could then submit the new VAE as a PR to the repo from which this model \
+                    was downloaded.
+                    """)
+            }
+            return zInputDescription
         }
     }
     


### PR DESCRIPTION
Small improvement for clarification. Related to #176.

--- 

Thank you for your interest in contributing to Core ML Stable Diffusion! Please review [CONTRIBUTING.md](../CONTRIBUTING.md) first. If you would like to proceed with making a pull request, please indicate your agreement to the terms outlined in CONTRIBUTING.md by checking the box below. If not, please go ahead and fork this repo and make your updates.

We appreciate your interest in the project!

Do not erase the below when submitting your pull request:
#########

- [x] I agree to the terms outlined in CONTRIBUTING.md 
