### PR TITLE
Fix text encoder conversion with transformers v4.29.x

### DIFF
--- a/python_coreml_stable_diffusion/torch2coreml.py
+++ b/python_coreml_stable_diffusion/torch2coreml.py
@@ -283,8 +283,8 @@ def convert_text_encoder(pipe, args):
     }
     logger.info(f"Sample inputs spec: {sample_text_encoder_inputs_spec}")
 
-    def _build_causal_attention_mask(self, bsz, seq_len, dtype):
-        mask = torch.ones((bsz, seq_len, seq_len), dtype=dtype) * -1e4
+    def _build_causal_attention_mask(self, bsz, seq_len, dtype, device=None):
+        mask = torch.ones((bsz, seq_len, seq_len), dtype=dtype, device=device) * -1e4
         mask.triu_(1)
         mask = mask.unsqueeze(1)
         return mask


### PR DESCRIPTION
Currently, on a fresh setup of the environment, text encoder models fail to convert with the following error:

<details>
<summary>Stacktrace</summary>

```
INFO:__main__:JIT tracing text_encoder..
Traceback (most recent call last):
  File "/Users/zsolt/miniconda3/envs/coreml_stable_diffusion/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/zsolt/miniconda3/envs/coreml_stable_diffusion/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/zsolt/Work/ml-stable-diffusion/python_coreml_stable_diffusion/torch2coreml.py", line 1311, in <module>
    main(args)
  File "/Users/zsolt/Work/ml-stable-diffusion/python_coreml_stable_diffusion/torch2coreml.py", line 1181, in main
    convert_text_encoder(pipe, args)
  File "/Users/zsolt/Work/ml-stable-diffusion/python_coreml_stable_diffusion/torch2coreml.py", line 308, in convert_text_encoder
    reference_text_encoder = torch.jit.trace(
  File "/Users/zsolt/miniconda3/envs/coreml_stable_diffusion/lib/python3.8/site-packages/torch/jit/_trace.py", line 794, in trace
    return trace_module(
  File "/Users/zsolt/miniconda3/envs/coreml_stable_diffusion/lib/python3.8/site-packages/torch/jit/_trace.py", line 1056, in trace_module
    module._c._create_method_from_trace(
  File "/Users/zsolt/miniconda3/envs/coreml_stable_diffusion/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/Users/zsolt/miniconda3/envs/coreml_stable_diffusion/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1488, in _slow_forward
    result = self.forward(*input, **kwargs)
  File "/Users/zsolt/Work/ml-stable-diffusion/python_coreml_stable_diffusion/torch2coreml.py", line 303, in forward
    return self.text_encoder(input_ids, return_dict=False)
  File "/Users/zsolt/miniconda3/envs/coreml_stable_diffusion/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/Users/zsolt/miniconda3/envs/coreml_stable_diffusion/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1488, in _slow_forward
    result = self.forward(*input, **kwargs)
  File "/Users/zsolt/miniconda3/envs/coreml_stable_diffusion/lib/python3.8/site-packages/transformers/models/clip/modeling_clip.py", line 816, in forward
    return self.text_model(
  File "/Users/zsolt/miniconda3/envs/coreml_stable_diffusion/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/Users/zsolt/miniconda3/envs/coreml_stable_diffusion/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1488, in _slow_forward
    result = self.forward(*input, **kwargs)
  File "/Users/zsolt/miniconda3/envs/coreml_stable_diffusion/lib/python3.8/site-packages/transformers/models/clip/modeling_clip.py", line 717, in forward
    causal_attention_mask = self._build_causal_attention_mask(
TypeError: _build_causal_attention_mask() got an unexpected keyword argument 'device'
```
</details>

---

This is caused by an internal change in transformers v4.29.0, where a new keyword argument `device` was [introduced](https://github.com/huggingface/transformers/blob/v4.29.1/src/transformers/models/clip/modeling_clip.py#L755) to CLIPTextTransformer's `_build_causal_attention_mask` method.

The conversion script overrides this method with its own implementation, but the replacement method doesn't (yet) have this parameter, causing the TypeError.

This PR adds the argument and makes the conversion compatible with transformers v4.29.x.
(And probably breaks compatibility with v4.28 and before, but since versions are not pinned in this repo, new users will always have the latest version installed.)

---

- [x] I agree to the terms outlined in CONTRIBUTING.md 
