### PR TITLE
Remove “import Cocoa” to make it work on iOS again

### DIFF
--- a/swift/StableDiffusionCLI/main.swift
+++ b/swift/StableDiffusionCLI/main.swift
@@ -7,7 +7,6 @@ import CoreML
 import Foundation
 import StableDiffusion
 import UniformTypeIdentifiers
-import Cocoa
 import CoreImage
 
 @available(iOS 16.2, macOS 13.1, *)


### PR DESCRIPTION
Cocoa is not available on iOS — therefore, the import prevents use of the package on iOS.