### PR TITLE
Extend ControlNet image conversion with hole punching for InPaint

### DIFF
--- a/swift/StableDiffusion/pipeline/CGImage+vImage.swift
+++ b/swift/StableDiffusion/pipeline/CGImage+vImage.swift
@@ -111,7 +111,7 @@ extension CGImage {
             let destBPtr = destinationB.data.assumingMemoryBound(to: Float.self)
 
             for i in 0..<Int(width) * Int(height) {
-                if destAPtr.advanced(by: i).pointee < 1 {
+                if destAPtr.advanced(by: i).pointee == 0 {
                     destRPtr.advanced(by: i).pointee = -1
                     destGPtr.advanced(by: i).pointee = -1
                     destBPtr.advanced(by: i).pointee = -1

--- a/swift/StableDiffusion/pipeline/CGImage+vImage.swift
+++ b/swift/StableDiffusion/pipeline/CGImage+vImage.swift
@@ -105,6 +105,19 @@ extension CGImage {
             
             vImageConvert_ARGB8888toPlanarF(&mediumDesination, &destinationA, &destinationR, &destinationG, &destinationB, &maxFloat, &minFloat, .zero)
            
+            let destAPtr = destinationA.data.assumingMemoryBound(to: Float.self)
+            let destRPtr = destinationR.data.assumingMemoryBound(to: Float.self)
+            let destGPtr = destinationG.data.assumingMemoryBound(to: Float.self)
+            let destBPtr = destinationB.data.assumingMemoryBound(to: Float.self)
+
+            for i in 0..<Int(width) * Int(height) {
+                if destAPtr.advanced(by: i).pointee < 1 {
+                    destRPtr.advanced(by: i).pointee = -1
+                    destGPtr.advanced(by: i).pointee = -1
+                    destBPtr.advanced(by: i).pointee = -1
+                }
+            }
+
             let redData = Data(bytes: destinationR.data, count: Int(width) * Int(height) * MemoryLayout<Float>.size)
             let greenData = Data(bytes: destinationG.data, count: Int(width) * Int(height) * MemoryLayout<Float>.size)
             let blueData = Data(bytes: destinationB.data, count: Int(width) * Int(height) * MemoryLayout<Float>.size)


### PR DESCRIPTION
The inpainting ControlNet model expects the masked areas to be filled with -1. This never occured with the original conversion, as the pixel data was converted to values between [0;1], thus the inpainting CN model never had any effect (apart from maybe generating artifacts).

This commit uses the _previously discarded_ alpha channel of the source image to mark masked pixels: any non-opaque pixel is cleared out to -1. For an end-user, this allows creating masks simply by erasing areas with Preview to transparent, saving the result as PNG, and feeding it to the ControlNet.

See an example over at [MochiDiffusion](https://github.com/godly-devotion/MochiDiffusion/pull/272).

#########

- [x] I agree to the terms outlined in CONTRIBUTING.md 
