### PR TITLE
Restore compatibility with Xcode 14.3/macOS SDK 13.4

### DIFF
--- a/swift/StableDiffusion/pipeline/MultilingualTextEncoder.swift
+++ b/swift/StableDiffusion/pipeline/MultilingualTextEncoder.swift
@@ -5,6 +5,7 @@ import Foundation
 import NaturalLanguage
 import CoreML
 
+#if canImport(NaturalLanguage.NLContextualEmbedding)
 @available(iOS 17.0, macOS 14.0, *)
 public struct MultilingualTextEncoder: TextEncoderModel {
     let adapter: ManagedMLModel?
@@ -174,11 +175,13 @@ extension MultilingualTextEncoder {
         }
     }
 }
+#endif
 
 @available(iOS 16.2, macOS 13.1, *)
 public enum Script: String {
     case latin, cyrillic, cjk
 
+#if canImport(NaturalLanguage.NLScript)
     @available(iOS 17.0, macOS 14.0, *)
     var asNLScript: NLScript {
         switch self {
@@ -187,4 +190,5 @@ public enum Script: String {
         case .cjk: return .simplifiedChinese
         }
     }
+#endif
 }

--- a/swift/StableDiffusion/pipeline/StableDiffusionPipeline+Resources.swift
+++ b/swift/StableDiffusion/pipeline/StableDiffusionPipeline+Resources.swift
@@ -69,6 +69,8 @@ public extension StableDiffusionPipeline {
         /// Expect URL of each resource
         let urls = ResourceURLs(resourcesAt: baseURL)
         let textEncoder: TextEncoderModel
+
+#if canImport(NaturalLanguage.NLScript)
         if useMultilingualTextEncoder {
             guard #available(macOS 14.0, iOS 17.0, *) else { throw Error.unsupportedOSVersion }
             textEncoder = MultilingualTextEncoder(
@@ -80,6 +82,10 @@ public extension StableDiffusionPipeline {
             let tokenizer = try BPETokenizer(mergesAt: urls.mergesURL, vocabularyAt: urls.vocabURL)
             textEncoder = TextEncoder(tokenizer: tokenizer, modelAt: urls.textEncoderURL, configuration: config)
         }
+#else
+        let tokenizer = try BPETokenizer(mergesAt: urls.mergesURL, vocabularyAt: urls.vocabURL)
+        textEncoder = TextEncoder(tokenizer: tokenizer, modelAt: urls.textEncoderURL, configuration: config)
+#endif
 
         // ControlNet model
         var controlNet: ControlNet? = nil


### PR DESCRIPTION
This PR adds three strategically placed `#if canImport` statements, that would allow anyone not on beta macOS and beta Xcode versions to build ml-stable-diffusion 1.0.0 — with the multilingual text encoding disabled.

If it was accepted, it would definitely help working with the library during the Xcode 15 transitionary period.

#########

- [x] I agree to the terms outlined in CONTRIBUTING.md 
