### PR TITLE
Support for denoised latent images on progress updates

### DIFF
--- a/swift/StableDiffusion/pipeline/DPMSolverMultistepScheduler.swift
+++ b/swift/StableDiffusion/pipeline/DPMSolverMultistepScheduler.swift
@@ -37,7 +37,7 @@ public final class DPMSolverMultistepScheduler: Scheduler {
     public let useLowerOrderFinal = true
     
     // Stores solverOrder (2) items
-    private(set) var modelOutputs: [MLShapedArray<Float32>] = []
+    public private(set) var modelOutputs: [MLShapedArray<Float32>] = []
 
     /// Create a scheduler that uses a second order DPM-Solver++ algorithm.
     ///

--- a/swift/StableDiffusion/pipeline/Scheduler.swift
+++ b/swift/StableDiffusion/pipeline/Scheduler.swift
@@ -274,7 +274,6 @@ public final class PNDMScheduler: Scheduler {
     }
 
     /// Convert the model output to the corresponding type the algorithm needs.
-    /// This implementation is for second-order DPM-Solver++ assuming epsilon prediction.
     func convertModelOutput(modelOutput: MLShapedArray<Float32>, timestep: Int, sample: MLShapedArray<Float32>) -> MLShapedArray<Float32> {
         assert(modelOutput.scalarCount == sample.scalarCount)
         let scalarCount = modelOutput.scalarCount

--- a/swift/StableDiffusion/pipeline/StableDiffusionPipeline.Configuration.swift
+++ b/swift/StableDiffusion/pipeline/StableDiffusionPipeline.Configuration.swift
@@ -37,6 +37,8 @@ extension StableDiffusionPipeline {
         public var controlNetInputs: [CGImage] = []
         /// Safety checks are only performed if `self.canSafetyCheck && !disableSafety`
         public var disableSafety: Bool = false
+        /// Enables progress updates to decode `currentImages` from denoised latent images for better previews
+        public var useDenoisedIntermediates: Bool = false
         /// The type of Scheduler to use.
         public var schedulerType: StableDiffusionScheduler = .pndmScheduler
         /// The type of RNG to use

--- a/swift/StableDiffusion/pipeline/StableDiffusionPipeline.swift
+++ b/swift/StableDiffusion/pipeline/StableDiffusionPipeline.swift
@@ -265,8 +265,12 @@ public struct StableDiffusionPipeline: ResourceManaging {
                     sample: latents[i]
                 )
 
-                denoisedLatents.append(scheduler[i].modelOutputs.last ?? latents[i])
+                if let denoisedLatent = scheduler[i].modelOutputs.last {
+                    denoisedLatents.append(denoisedLatent)
+                }
             }
+
+            let currentLatentSamples = config.useDenoisedIntermediates ? denoisedLatents : latents
 
             // Report progress
             let progress = Progress(
@@ -274,7 +278,7 @@ public struct StableDiffusionPipeline: ResourceManaging {
                 prompt: config.prompt,
                 step: step,
                 stepCount: timeSteps.count,
-                currentLatentSamples: denoisedLatents,
+                currentLatentSamples: currentLatentSamples,
                 configuration: config
             )
             if !progressHandler(progress) {


### PR DESCRIPTION
Working on adding preview images to the demo app here https://github.com/huggingface/swift-coreml-diffusers/pull/65

However, I noticed that when accessing the computed property `currentImage` from [`StableDiffusionPipeline.Progress`](https://github.com/apple/ml-stable-diffusion/blob/823d21ecf4a45dc14f61c7bf698209cfb1c8815d/swift/StableDiffusion/pipeline/StableDiffusionPipeline.swift#L399) at any point before the final step, the images are quite noisy (and can trigger the safety check for some reason.)

This PR just converts the noisy latent images into their denoised versions (for both schedulers) before sending them through to the progress update.


Here's an example:

https://github.com/apple/ml-stable-diffusion/assets/1981179/9bcdf9b8-6ca5-4ca0-a15f-bcb23232c173

Denoised:

https://github.com/apple/ml-stable-diffusion/assets/1981179/8ebd9235-34d7-457a-8056-345e1f9b58ab



Do not erase the below when submitting your pull request:
#########

- [x] I agree to the terms outlined in CONTRIBUTING.md 
