### PR TITLE
Multi-ControlNet Speed Improvements

### DIFF
--- a/swift/StableDiffusion/pipeline/ControlNet.swift
+++ b/swift/StableDiffusion/pipeline/ControlNet.swift
@@ -99,13 +99,15 @@ public struct ControlNet: ResourceManaging {
             for n in 0..<results.count {
                 let result = results.features(at: n)
                 for k in result.featureNames {
-                    let newValue = result.featureValue(for: k)!.shapedArrayValue(of: Float32.self)!
+                    let newValue = result.featureValue(for: k)!.multiArrayValue!
                     if modelIndex == 0 {
-                        outputs[n][k] = newValue
+                        outputs[n][k] = MLShapedArray<Float32>(newValue)
                     } else {
-                        outputs[n][k]!.withUnsafeMutableShapedBufferPointer { pt, _, _ in
-                            for (i, v) in newValue.scalars.enumerated() { pt[i] += v }
-                        }
+                        let outputArray = MLMultiArray(outputs[n][k]!)
+                        let count = newValue.count
+                        let inputPointer = newValue.dataPointer.assumingMemoryBound(to: Float.self)
+                        let outputPointer = outputArray.dataPointer.assumingMemoryBound(to: Float.self)
+                        vDSP_vadd(inputPointer, 1, outputPointer, 1, outputPointer, 1, vDSP_Length(count))
                     }
                 }
             }


### PR DESCRIPTION
Implements Accelerate vectorized routines in ControlNet.swift, increasing execution times by 5.6x when using multiple ControlNets, as suggested by @atiorh in #212.

Before:
4.75 seconds / step

After:
0.84 seconds / step

_Tested using Stable Diffusion 1.5 with lllyasviel/control_v11p_sd15_shuffle and lllyasviel/control_v11p_sd15_canny
M1 Max MacBook Pro 16_

Thank you for your interest in contributing to Core ML Stable Diffusion! Please review [CONTRIBUTING.md](../CONTRIBUTING.md) first. If you would like to proceed with making a pull request, please indicate your agreement to the terms outlined in CONTRIBUTING.md by checking the box below. If not, please go ahead and fork this repo and make your updates.

We appreciate your interest in the project!

Do not erase the below when submitting your pull request:
#########

- [x] I agree to the terms outlined in CONTRIBUTING.md 
