### PR TITLE
Support for SDXL conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ This generally takes 15-20 minutes on an M1 MacBook Pro. Upon successful executi
 
 - `--unet-support-controlnet`: enables a converted UNet model to receive additional inputs from ControlNet. This is required for generating image with using ControlNet and saved with a different name, `*_control-unet.mlpackage`, distinct from normal UNet. On the other hand, this UNet model can not work without ControlNet. Please use normal UNet for just txt2img.
 
+- `--pipeline-type`: Defaults to `SD` which will use the standard Stable Diffusion pipeline. `--pipeline-type SDXL` will convert the models for Stable Diffusion XL.
+
 </details>
 
 ## <a name="image-generation-with-python"></a> Image Generation with Python

--- a/python_coreml_stable_diffusion/torch2coreml.py
+++ b/python_coreml_stable_diffusion/torch2coreml.py
@@ -557,7 +557,7 @@ def modify_coremltools_torch_frontend_badbmm():
 
 def modify_coremltools_torch_frontend_scaled_dot_product_attention():
     """
-    Modifies coremltools torch frontend for scaled_dot_product_attention having 7 inputs instead of 6:
+    Modifies coremltools torch frontend for scaled_dot_product_attention sometimes having 7 inputs instead of 6:
     """
     import math as _math
     from coremltools.converters.mil import register_torch_op
@@ -586,7 +586,7 @@ def modify_coremltools_torch_frontend_scaled_dot_product_attention():
         See details at:
         https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html
         """
-        q, k, v, attn_mask, dropout, is_causal, empty = _get_inputs(context, node, expected=7)
+        q, k, v, attn_mask, dropout, is_causal = _get_inputs(context, node, min_expected=6)[:6]
         if attn_mask is not None and is_causal.val:
             raise ValueError(
                 "scaled_dot_product_attention op: attn_mask cannot be provided when is_causal is set to True."
@@ -681,6 +681,7 @@ def convert_vae_decoder(pipe, args):
 
     modify_coremltools_torch_frontend_badbmm()
     modify_coremltools_torch_frontend_scaled_dot_product_attention()
+    
     coreml_vae_decoder, out_path = _convert_to_coreml(
         "vae_decoder", traced_vae_decoder, sample_vae_decoder_inputs,
         ["image"], args,
@@ -782,6 +783,7 @@ def convert_vae_encoder(pipe, args):
 
     modify_coremltools_torch_frontend_badbmm()
     modify_coremltools_torch_frontend_scaled_dot_product_attention()
+ 
     coreml_vae_encoder, out_path = _convert_to_coreml(
         "vae_encoder", traced_vae_encoder, sample_vae_encoder_inputs,
         ["latent"], args)

--- a/python_coreml_stable_diffusion/torch2coreml.py
+++ b/python_coreml_stable_diffusion/torch2coreml.py
@@ -403,11 +403,10 @@ def convert_text_encoder_xl(pipe, args, text_encoder_name):
 
 
     # Create sample inputs for tracing, conversion and correctness verification
-    if hasattr(pipe, "text_encoder") and pipe.text_encoder is not None:
-        reference_text_encoder = pipe.text_encoder
+    reference_text_encoder = getattr(pipe, text_encoder_name)
+    if hasattr(pipe, "tokenizer") and pipe.tokenizer is not None:
         text_encoder_sequence_length = pipe.tokenizer.model_max_length
-    elif hasattr(pipe, "text_encoder_2") and pipe.text_encoder_2 is not None:
-        reference_text_encoder = pipe.text_encoder_2
+    elif hasattr(pipe, "tokenizer_2") and pipe.tokenizer_2 is not None:
         text_encoder_sequence_length = pipe.tokenizer_2.model_max_length
 
     reference_text_encoder.to(args.device)

--- a/python_coreml_stable_diffusion/torch2coreml.py
+++ b/python_coreml_stable_diffusion/torch2coreml.py
@@ -398,9 +398,15 @@ def convert_text_encoder_xl(pipe, args, text_encoder_name):
             f"`{text_encoder_name}` already exists at {out_path}, skipping conversion."
         )
         return
-    
-    reference_text_encoder = getattr(pipe, text_encoder_name)
 
+    if getattr(pipe, text_encoder_name) is None:
+        logger.warning(
+            f"diffusers pipeline for {args.model_version} does not have a `{text_encoder_name}` module! " \
+            f"`--convert-{text_encoder_name}` will be ignored."
+        )
+        return
+
+    reference_text_encoder = getattr(pipe, text_encoder_name)
 
     # Create sample inputs for tracing, conversion and correctness verification
     reference_text_encoder = getattr(pipe, text_encoder_name)
@@ -862,7 +868,7 @@ def convert_unet(pipe, args):
             args.latent_w or pipe.unet.config.sample_size,  # W
         )
 
-        if not hasattr(pipe, "text_encoder") and not hasattr(pipe, "text_encoder_2"):
+        if getattr(pipe, "text_encoder") is None and getattr(pipe, "text_encoder_2") is None:
             raise RuntimeError(
                 "convert_text_encoder() deletes pipe.text_encoder to save RAM. "
                 "Please use convert_unet() before convert_text_encoder()")

--- a/python_coreml_stable_diffusion/torch2coreml.py
+++ b/python_coreml_stable_diffusion/torch2coreml.py
@@ -291,7 +291,7 @@ def convert_text_encoder(pipe, args):
         text_encoder_vocab_size = pipe.text_encoder.config.vocab_size
         text_encoder_sequence_length = pipe.tokenizer.model_max_length
     elif hasattr(pipe, "text_encoder_2") and pipe.text_encoder_2 is not None:
-        text_token_sequence_length = pipe.text_encoder_2.config.vocab_size
+        text_encoder_vocab_size = pipe.text_encoder_2.config.vocab_size
         text_encoder_sequence_length = pipe.tokenizer_2.model_max_length
 
     sample_text_encoder_inputs = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 coremltools>=7.0b1
-diffusers[torch]
+diffusers[torch]>=0.18.2
 torch
 transformers==4.29.2
 scipy
-scikit-learn
+scikit-learn<=1.1.2
 pytest
+invisible-watermark>=0.2.0


### PR DESCRIPTION
Here's a start for SDXL support 🦾

SDXL **base** conversion command:
`python -m python_coreml_stable_diffusion.torch2coreml --convert-text-encoder --convert-text-encoder-2 --convert-vae-decoder --convert-vae-encoder --convert-unet --model-version stabilityai/stable-diffusion-xl-base-0.9 --compute-unit ALL --attention-implementation ORIGINAL --bundle-resources-for-swift-cli  --pipeline-type SDXL -o <your_output_path>`

SDXL **refiner** conversion command:
`python -m python_coreml_stable_diffusion.torch2coreml --convert-text-encoder-2 --convert-vae-decoder --convert-vae-encoder --convert-unet --model-version stabilityai/stable-diffusion-xl-refiner-0.9 --compute-unit ALL --attention-implementation ORIGINAL --bundle-resources-for-swift-cli  --pipeline-type SDXL_REFINER -o <your_output_path>`

The bulk of the work was getting the Unet converting, since it uses the added embeddings for `time_ids` and `text_embed`. I've updated the unet.py code to simply match the current diffusers structure as much as needed to work, and keeping the encoder_hidden_states dimention that is friendly for ANE. The new text_encoders have a new output format, and the vae decoder is specifically exported in float32 because it overflows apparently (I was getting all black images when using float16). There appears to be some [fixes](https://huggingface.co/madebyollin/sdxl-vae-fp16-fix) out for this already so it may be temporary.

I've only tested inference on the base model, but I've confirmed they work about as quickly as the huggingface/diffusers implementation. Here's some example images generated from the output of this pipeline. On my M2 Mac Mini (32gb ram) I'm getting ~3.8s per step on just GPU.

All 1024x1024 but a little rough in the details, which justifies the need for a refiner. However, this may not be needed depending on what SDXL 1.0 is like.

"Labrador in the style of Vermeer" 25 steps 

![Labrador_in_the_style_of_Vermeer 25 steps](https://github.com/apple/ml-stable-diffusion/assets/1981179/b8cec28f-9677-4246-b1d4-3e2e1e721b84)

"a high quality photo of a surfing dog" 50 steps

![image](https://github.com/apple/ml-stable-diffusion/assets/1981179/1592f148-3669-4f4b-ab64-55d6d119c0b9)

"a photo of an astronaut riding a horse on mars" 50 steps

![a_photo_of_an_astronaut_riding_a_horse_on_mars](https://github.com/apple/ml-stable-diffusion/assets/1981179/176d636a-80b2-4cea-977d-c51a5709c0ec)

## Note on split_einsum
Through experimentation I noticed that either of the split einsum implementations do not transfer over directly to SDXL. Took roughly 10x the time for conversion and inference. 

## Note on schedulers
The built in schedulers appear to work fine, although the SDXL config prefers `EulerDiscreteScheduler`, that may be a todo for later. 

## Note on safety checker
This model does not come with a safety checker, but it does require a new package to load correctly `invisible-watermark>=0.2.0`. It appears to be just a simple matrix multiplication on the image so that may not be required in the conversion script either.

@atiorh I haven't included the inference code here because I wanted to ask - would you prefer a separate PR or is this one fine?

----

Thank you for your interest in contributing to Core ML Stable Diffusion! Please review [CONTRIBUTING.md](../CONTRIBUTING.md) first. If you would like to proceed with making a pull request, please indicate your agreement to the terms outlined in CONTRIBUTING.md by checking the box below. If not, please go ahead and fork this repo and make your updates.

We appreciate your interest in the project!

Do not erase the below when submitting your pull request:
#########

- [x] I agree to the terms outlined in CONTRIBUTING.md 
