### PR TITLE
Support for SDXL inference

### DIFF
--- a/swift/StableDiffusion/pipeline/MultilingualTextEncoder.swift
+++ b/swift/StableDiffusion/pipeline/MultilingualTextEncoder.swift
@@ -52,7 +52,7 @@ public struct MultilingualTextEncoder: TextEncoderModel {
     ///
     ///  - Parameter text: The input text.
     ///  - Returns: An embedding shaped array.
-    public func encode(_ text: String) throws -> MLShapedArray<Float> {
+    public func encode(_ text: String) throws -> (MLShapedArray<Float32>, MLShapedArray<Float32>) {
         guard embeddingModel.hasAvailableAssets else {
             throw Error.missingEmbeddingResource
         }
@@ -78,10 +78,10 @@ public struct MultilingualTextEncoder: TextEncoderModel {
 
         if adapter == nil {
             // Return embeddings with shape [1, 256, 512].
-            return MLShapedArray(converting: shapedEmbeddings)
+            return (MLShapedArray(converting: shapedEmbeddings), nil)
         } else {
             // Project the embeddings to the correct CLIP model input shape of [1, 768, 1, 256].
-            return try projectEmbeddings(shapedEmbeddings)
+            return (try projectEmbeddings(shapedEmbeddings), nil)
         }
     }
 

--- a/swift/StableDiffusion/pipeline/StableDiffusionPipelineXL.swift
+++ b/swift/StableDiffusion/pipeline/StableDiffusionPipelineXL.swift
@@ -1,0 +1,217 @@
+// For licensing see accompanying LICENSE.md file.
+// Copyright (C) 2022 Apple Inc. All Rights Reserved.
+
+import Accelerate
+import CoreGraphics
+import CoreML
+import Foundation
+import NaturalLanguage
+
+
+
+/// A pipeline used to generate image samples from text input using stable diffusion xl
+///
+/// This implementation matches:
+/// [Hugging Face Diffusers Pipeline](https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py)
+@available(iOS 16.2, macOS 13.1, *)
+public class StableDiffusionPipelineXL: StableDiffusionPipeline {
+
+    /// Keep track of whether the model requires an aesthetic score in it's added embedding
+    /// This is only required for the SDXL refiner
+    var requiresAestheticsScore: Bool = false
+
+    /// Image generation using stable diffusion
+    /// - Parameters:
+    ///   - configuration: Image generation configuration
+    ///   - progressHandler: Callback to perform after each step, stops on receiving false response
+    /// - Returns: An array of `imageCount` optional images.
+    ///            The images will be nil if safety checks were performed and found the result to be un-safe
+    public override func generateImages(
+        configuration config: Configuration,
+        progressHandler: (Progress) -> Bool = { _ in true }
+    ) throws -> [CGImage?] {
+        // Keep track of whether the model requires an aesthetic score
+        var requiresAestheticsScore = false
+
+        // Try to encode the input prompt and negative prompt with textEncoder if it's not nil
+        var promptEmbedding1Hidden: MLShapedArray<Float32>?
+        var negativePromptEmbedding1Hidden: MLShapedArray<Float32>?
+        if let textEncoder = textEncoder {
+            (promptEmbedding1Hidden, _) = try textEncoder.encode(config.prompt)
+            (negativePromptEmbedding1Hidden, _) = try textEncoder.encode(config.negativePrompt)
+
+            // Unload resources to reduce memory if flag is set
+            if reduceMemory {
+                textEncoder.unloadResources()
+            }
+        } else {
+            // text_encoder is nil, since this is an XL pipeline, that means this is a refiner model
+            requiresAestheticsScore = true
+        }
+
+        // Try to encode the input prompt and negative prompt with textEncoder2 if it's not nil
+        var promptEmbedding2Hidden: MLShapedArray<Float32>?
+        var promptEmbedding2Pooled: MLShapedArray<Float32>?
+        var negativePromptEmbedding2Hidden: MLShapedArray<Float32>?
+        var negativePromptEmbedding2Pooled: MLShapedArray<Float32>?
+        if let textEncoder2 = textEncoder2 {
+            (promptEmbedding2Hidden, promptEmbedding2Pooled) = try textEncoder2.encode(config.prompt)
+            (negativePromptEmbedding2Hidden, negativePromptEmbedding2Pooled) = try textEncoder2.encode(config.negativePrompt)
+
+            // Unload resources to reduce memory if flag is set
+            if reduceMemory {
+                textEncoder2.unloadResources()
+            }
+        }
+
+        var embeddingsToConcatenate = [MLShapedArray<Float32>]()
+
+        if let promptEmbedding1Hidden = promptEmbedding1Hidden {
+            embeddingsToConcatenate.append(promptEmbedding1Hidden)
+        }
+
+        if let promptEmbedding2Hidden = promptEmbedding2Hidden {
+            embeddingsToConcatenate.append(promptEmbedding2Hidden)
+        }
+
+        var negativeEmbeddingsToConcatenate = [MLShapedArray<Float32>]()
+
+        if let negativePromptEmbedding1Hidden = negativePromptEmbedding1Hidden {
+            negativeEmbeddingsToConcatenate.append(negativePromptEmbedding1Hidden)
+        }
+
+        if let negativePromptEmbedding2Hidden = negativePromptEmbedding2Hidden {
+            negativeEmbeddingsToConcatenate.append(negativePromptEmbedding2Hidden)
+        }
+
+        let concatNegativeEmbedding = MLShapedArray<Float32>(
+            concatenating: negativeEmbeddingsToConcatenate,
+            alongAxis: -1
+        )
+
+        let concatPromptEmbedding = MLShapedArray<Float32>(
+            concatenating: embeddingsToConcatenate,
+            alongAxis: -1
+        )
+
+        let encoderHiddenStates = MLShapedArray<Float32>(
+            concatenating: [concatNegativeEmbedding, concatPromptEmbedding],
+            alongAxis: 0
+        )
+
+        let hiddenStates = useMultilingualTextEncoder ? encoderHiddenStates : toHiddenStates(encoderHiddenStates)
+
+        guard let negativeAddEmbed = negativePromptEmbedding2Pooled,
+              let addEmbed = promptEmbedding2Pooled else { return [] }
+
+        let addEmbeds = MLShapedArray<Float32>(
+            concatenating: [negativeAddEmbed, addEmbed],
+            alongAxis: 0
+        )
+
+        var timeIds = MLShapedArray<Float32>(scalars: [1024.0, 1024.0, 0.0, 0.0, 1024.0, 1024.0,
+                                                       1024.0, 1024.0, 0.0, 0.0, 1024.0, 1024.0], shape: [2, 6])
+        if (requiresAestheticsScore) {
+            timeIds = MLShapedArray<Float32>(scalars: [1024.0, 1024.0, 0.0, 0.0, 2.5,
+                                                       1024.0, 1024.0, 0.0, 0.0, 6], shape: [2, 5])
+        }
+
+
+        /// Setup schedulers
+        let scheduler: [Scheduler] = (0..<config.imageCount).map { _ in
+            switch config.schedulerType {
+            case .pndmScheduler: return PNDMScheduler(stepCount: config.stepCount)
+            case .dpmSolverMultistepScheduler: return DPMSolverMultistepScheduler(stepCount: config.stepCount)
+            }
+        }
+
+        // Generate random latent samples from specified seed
+        var latents: [MLShapedArray<Float32>] = try generateLatentSamples(configuration: config, scheduler: scheduler[0])
+        if reduceMemory {
+            encoder?.unloadResources()
+        }
+        let timestepStrength: Float? = config.mode == .imageToImage ? config.strength : nil
+
+        // Convert cgImage for ControlNet into MLShapedArray
+        let controlNetConds = try config.controlNetInputs.map { cgImage in
+            let shapedArray = try cgImage.plannerRGBShapedArray(minValue: 0.0, maxValue: 1.0)
+            return MLShapedArray(
+                concatenating: [shapedArray, shapedArray],
+                alongAxis: 0
+            )
+        }
+
+        // De-noising loop
+        let timeSteps: [Int] = scheduler[0].calculateTimesteps(strength: timestepStrength)
+        for (step,t) in timeSteps.enumerated() {
+
+            // Expand the latents for classifier-free guidance
+            // and input to the Unet noise prediction model
+            let latentUnetInput = latents.map {
+                MLShapedArray<Float32>(concatenating: [$0, $0], alongAxis: 0)
+            }
+
+            // Before Unet, execute controlNet and add the output into Unet inputs
+            let additionalResiduals = try controlNet?.execute(
+                latents: latentUnetInput,
+                timeStep: t,
+                hiddenStates: hiddenStates,
+                images: controlNetConds
+            )
+
+            // Predict noise residuals from latent samples
+            // and current time step conditioned on hidden states
+            var noise = try unet.predictNoise(
+                latents: latentUnetInput,
+                timeStep: t,
+                hiddenStates: hiddenStates,
+                textEmbeds: addEmbeds,
+                timeIds: timeIds,
+                additionalResiduals: additionalResiduals
+            )
+
+            noise = performGuidance(noise, config.guidanceScale)
+
+            // Retreive denoised latents from scheduler to pass into progress report
+            var denoisedLatents: [MLShapedArray<Float32>] = []
+
+            // Have the scheduler compute the previous (t-1) latent
+            // sample given the predicted noise and current sample
+            for i in 0..<config.imageCount {
+                latents[i] = scheduler[i].step(
+                    output: noise[i],
+                    timeStep: t,
+                    sample: latents[i]
+                )
+
+                if let denoisedLatent = scheduler[i].modelOutputs.last {
+                    denoisedLatents.append(denoisedLatent)
+                }
+            }
+
+            let currentLatentSamples = config.useDenoisedIntermediates ? denoisedLatents : latents
+
+            // Report progress
+            let progress = Progress(
+                pipeline: self,
+                prompt: config.prompt,
+                step: step,
+                stepCount: timeSteps.count,
+                currentLatentSamples: currentLatentSamples,
+                configuration: config
+            )
+            if !progressHandler(progress) {
+                // Stop if requested by handler
+                return []
+            }
+        }
+
+        if reduceMemory {
+            controlNet?.unloadResources()
+            unet.unloadResources()
+        }
+
+        // Decode the latent samples to images
+        return try decodeToImages(latents, configuration: config)
+    }
+}

--- a/swift/StableDiffusion/pipeline/Unet.swift
+++ b/swift/StableDiffusion/pipeline/Unet.swift
@@ -80,6 +80,8 @@ public struct Unet: ResourceManaging {
         latents: [MLShapedArray<Float32>],
         timeStep: Int,
         hiddenStates: MLShapedArray<Float32>,
+        textEmbeds: MLShapedArray<Float32>? = nil,
+        timeIds: MLShapedArray<Float32>? = nil,
         additionalResiduals: [[String: MLShapedArray<Float32>]]? = nil
     ) throws -> [MLShapedArray<Float32>] {
 
@@ -93,6 +95,10 @@ public struct Unet: ResourceManaging {
                 "timestep" : MLMultiArray(t),
                 "encoder_hidden_states": MLMultiArray(hiddenStates)
             ]
+            if let textEmbeds = textEmbeds, let timeIds = timeIds {
+                dict["text_embeds"] = MLMultiArray(textEmbeds)
+                dict["time_ids"] = MLMultiArray(timeIds)
+            }
             if let residuals = additionalResiduals?[$0.offset] {
                 for (k, v) in residuals {
                     dict[k] = MLMultiArray(v)

--- a/swift/StableDiffusionCLI/main.swift
+++ b/swift/StableDiffusionCLI/main.swift
@@ -177,7 +177,7 @@ struct StableDiffusionSample: ParsableCommand {
         let sampleTimer = SampleTimer()
         sampleTimer.start()
 
-        var pipelineConfig = StableDiffusionPipelineXL.Configuration(prompt: prompt)
+        var pipelineConfig = StableDiffusionPipeline.Configuration(prompt: prompt)
 
         pipelineConfig.negativePrompt = negativePrompt
         pipelineConfig.startingImage = startingImage
@@ -216,7 +216,7 @@ struct StableDiffusionSample: ParsableCommand {
     }
 
     func handleProgress(
-        _ progress: StableDiffusionPipelineXL.Progress,
+        _ progress: StableDiffusionPipeline.Progress,
         _ sampleTimer: SampleTimer
     ) {
         log("\u{1B}[1A\u{1B}[K")


### PR DESCRIPTION
Marking this as a WIP because I'd like to include refiner inference as well still.

To test this out, download one these models and put them in a `Resources/` folder (or use this branch #217 to convert them yourself)

https://huggingface.co/ZachNagengast/coreml-stable-diffusion-xl-base-v1.0
https://huggingface.co/ZachNagengast/coreml-stable-diffusion-xl-base-v1.0-palletized

Run this command in the CLI:

`swift run StableDiffusionSample "Labrador in the style of Vermeer" --resource-path <your_path>/Resources/ --seed 93 --output-path <your_path> --pipeline-type SDXL`

SDXL v1.0 looks pretty great!

![Labrador_in_the_style_of_Vermeer](https://github.com/apple/ml-stable-diffusion/assets/1981179/bfddf7d5-c90c-47a6-9606-febdb8e38fa4)


I chose to convert `StableDiffusionPipeline` from a struct to a class so that I could make the subclass `StableDiffusionPipelineXL` and override the generate function with the additional embeddings required for SDXL. Please let me know if you have suggestions on how to improve this, if any.


----
Thank you for your interest in contributing to Core ML Stable Diffusion! Please review [CONTRIBUTING.md](../CONTRIBUTING.md) first. If you would like to proceed with making a pull request, please indicate your agreement to the terms outlined in CONTRIBUTING.md by checking the box below. If not, please go ahead and fork this repo and make your updates.

We appreciate your interest in the project!

Do not erase the below when submitting your pull request:
#########

- [x] I agree to the terms outlined in CONTRIBUTING.md 
