### PR TITLE
Update main.swift

### DIFF
--- a/swift/StableDiffusionCLI/main.swift
+++ b/swift/StableDiffusionCLI/main.swift
@@ -62,7 +62,7 @@ struct StableDiffusionSample: ParsableCommand {
     @Option(help: "Output path")
     var outputPath: String = "./"
 
-    @Option(help: "Random seed")
+    @Option(help: "Provide set seed value, defaults to random seed")
     var seed: UInt32 = UInt32.random(in: 0...UInt32.max)
 
     @Option(help: "Controls the influence of the text prompt on sampling process (0=random images)")


### PR DESCRIPTION
See issue: https://github.com/apple/ml-stable-diffusion/issues/220

When running the --help argument (swift run StableDiffusionSample --help) the generated documentation calculates a random seed each time, and passes the result of the RNG as the default seed option.

The documentation implies that you have to provide some argument with --seed in order to get a random number, or otherwise it will provide the shown 'default value'. While this should be the other way around.

Run 1:
--seed Random seed (default: 3944433010)
Run 2:
--seed Random seed (default: 1029080931)
Run n:
--seed Random seed (default: 769278928)



- [x] I agree to the terms outlined in CONTRIBUTING.md 
