### PR TITLE
Use denoised latent for final decoder

### DIFF
--- a/swift/StableDiffusion/pipeline/StableDiffusionPipeline.swift
+++ b/swift/StableDiffusion/pipeline/StableDiffusionPipeline.swift
@@ -230,6 +230,10 @@ public struct StableDiffusionPipeline: StableDiffusionPipelineProtocol {
 
         // Generate random latent samples from specified seed
         var latents: [MLShapedArray<Float32>] = try generateLatentSamples(configuration: config, scheduler: scheduler[0])
+
+        // Store denoised latents from scheduler to pass into decoder
+        var denoisedLatents: [MLShapedArray<Float32>] = latents.map { MLShapedArray(converting: $0) }
+
         if reduceMemory {
             encoder?.unloadResources()
         }
@@ -253,7 +257,7 @@ public struct StableDiffusionPipeline: StableDiffusionPipelineProtocol {
             let latentUnetInput = latents.map {
                 MLShapedArray<Float32>(concatenating: [$0, $0], alongAxis: 0)
             }
-            
+
             // Before Unet, execute controlNet and add the output into Unet inputs
             let additionalResiduals = try controlNet?.execute(
                 latents: latentUnetInput,
@@ -273,9 +277,6 @@ public struct StableDiffusionPipeline: StableDiffusionPipelineProtocol {
 
             noise = performGuidance(noise, config.guidanceScale)
 
-            // Retrieve denoised latents from scheduler to pass into progress report
-            var denoisedLatents: [MLShapedArray<Float32>] = []
-
             // Have the scheduler compute the previous (t-1) latent
             // sample given the predicted noise and current sample
             for i in 0..<config.imageCount {
@@ -285,9 +286,7 @@ public struct StableDiffusionPipeline: StableDiffusionPipelineProtocol {
                     sample: latents[i]
                 )
 
-                if let denoisedLatent = scheduler[i].modelOutputs.last {
-                    denoisedLatents.append(denoisedLatent)
-                }
+                denoisedLatents[i] = scheduler[i].modelOutputs.last ?? latents[i]
             }
 
             let currentLatentSamples = config.useDenoisedIntermediates ? denoisedLatents : latents
@@ -313,7 +312,7 @@ public struct StableDiffusionPipeline: StableDiffusionPipelineProtocol {
         }
 
         // Decode the latent samples to images
-        return try decodeToImages(latents, configuration: config)
+        return try decodeToImages(denoisedLatents, configuration: config)
     }
 
     func generateLatentSamples(configuration config: Configuration, scheduler: Scheduler) throws -> [MLShapedArray<Float32>] {

--- a/swift/StableDiffusion/pipeline/StableDiffusionXLPipeline.swift
+++ b/swift/StableDiffusion/pipeline/StableDiffusionXLPipeline.swift
@@ -153,6 +153,10 @@ public struct StableDiffusionXLPipeline: StableDiffusionPipelineProtocol {
 
         // Generate random latent samples from specified seed
         var latents: [MLShapedArray<Float32>] = try generateLatentSamples(configuration: config, scheduler: scheduler[0])
+
+        // Store denoised latents from scheduler to pass into decoder
+        var denoisedLatents: [MLShapedArray<Float32>] = latents.map { MLShapedArray(converting: $0) }
+
         if reduceMemory {
             encoder?.unloadResources()
         }
@@ -180,9 +184,6 @@ public struct StableDiffusionXLPipeline: StableDiffusionPipelineProtocol {
 
             noise = performGuidance(noise, config.guidanceScale)
 
-            // Retrieve denoised latents from scheduler to pass into progress report
-            var denoisedLatents: [MLShapedArray<Float32>] = []
-
             // Have the scheduler compute the previous (t-1) latent
             // sample given the predicted noise and current sample
             for i in 0..<config.imageCount {
@@ -191,10 +192,8 @@ public struct StableDiffusionXLPipeline: StableDiffusionPipelineProtocol {
                     timeStep: t,
                     sample: latents[i]
                 )
-
-                if let denoisedLatent = scheduler[i].modelOutputs.last {
-                    denoisedLatents.append(denoisedLatent)
-                }
+                
+                denoisedLatents[i] = scheduler[i].modelOutputs.last ?? latents[i]
             }
 
             let currentLatentSamples = config.useDenoisedIntermediates ? denoisedLatents : latents
@@ -219,7 +218,7 @@ public struct StableDiffusionXLPipeline: StableDiffusionPipelineProtocol {
         }
 
         // Decode the latent samples to images
-        return try decodeToImages(latents, configuration: config)
+        return try decodeToImages(denoisedLatents, configuration: config)
     }
 
     func encodePrompt(_ prompt: String) throws -> (MLShapedArray<Float32>, MLShapedArray<Float32>) {


### PR DESCRIPTION
I noticed sometimes the final preview of the SDXL pipeline looked better than the actual output. This PR uses the final modelOutput as the latent that gets sent to the final decoding step. I believe this issue also applies to the non-xl pipeline. Previously it was sending the noisy latent from the last timestep, which was resulting in some mosaic artifacts on SDXL 1.0:

## SDXL
| Noisy      | Denoised |
| :---:        |    :---: |
| ![a_flying_pig_mosaic](https://github.com/apple/ml-stable-diffusion/assets/1981179/842eaa54-a9d6-4ca1-a1c0-9b47e44a78db) | ![a_flying_pig](https://github.com/apple/ml-stable-diffusion/assets/1981179/c0a2fea9-0946-45ba-bd5f-3861d4291b87) | 

Difference: 
<img width="631" alt="image" src="https://github.com/apple/ml-stable-diffusion/assets/1981179/329b8e49-66ad-416d-ab14-d0bf1789c70b">

## SD 1.5 (runway)
| Noisy      | Denoised |
| :---:        |    :---: |
| ![Labrador_in_the_style_of_Vermeer_noisy-127-scaled](https://github.com/apple/ml-stable-diffusion/assets/1981179/319b708c-05b8-4a4b-97c9-231e1d801ede) | ![Labrador_in_the_style_of_Vermeer_denoised-127-scaled](https://github.com/apple/ml-stable-diffusion/assets/1981179/18d29dbe-5d82-47aa-953b-8c04afeedeac) | 

Difference: 
<img width="652" alt="image" src="https://github.com/apple/ml-stable-diffusion/assets/1981179/9990c46b-1d9f-43c8-8d7d-b357d20240c8">

----
Thank you for your interest in contributing to Core ML Stable Diffusion! Please review [CONTRIBUTING.md](../CONTRIBUTING.md) first. If you would like to proceed with making a pull request, please indicate your agreement to the terms outlined in CONTRIBUTING.md by checking the box below. If not, please go ahead and fork this repo and make your updates.

We appreciate your interest in the project!

Do not erase the below when submitting your pull request:
#########

- [x] I agree to the terms outlined in CONTRIBUTING.md 
