### PR TITLE
Fix multiple issues in mixed bit compression pre analysis

### DIFF
--- a/python_coreml_stable_diffusion/mixed_bit_compression_pre_analysis.py
+++ b/python_coreml_stable_diffusion/mixed_bit_compression_pre_analysis.py
@@ -125,7 +125,7 @@ def fake_palettize(module, nbits, in_ngroups=1, out_ngroups=1):
 
     dtype = module.weight.data.dtype
     device = module.weight.data.device
-    val = module.weight.data.cpu().numpy().astype(np.float16)
+    val = module.weight.data.cpu().numpy()
     
     if out_ngroups == 1 and in_ngroups == 1:
         lut, indices = compress_kmeans(val=val, nbits=nbits)
@@ -404,7 +404,7 @@ def plot(results, args):
 def main(args):
 
     # Initialize pipe
-    pipe = get_pipe(args.model_version)
+    pipe = get_pipeline(args)
 
     # Preserve a pristine copy for reference outputs
     ref_pipe = deepcopy(pipe)
@@ -533,6 +533,7 @@ if __name__ == "__main__":
         help="Default number of bits to use for palettization",
         choices=tuple(NBITS + [16]),
         default=16,
+        type=int,
     )
     parser.add_argument(
         "--num-recipes",

--- a/python_coreml_stable_diffusion/mixed_bit_compression_pre_analysis.py
+++ b/python_coreml_stable_diffusion/mixed_bit_compression_pre_analysis.py
@@ -125,7 +125,7 @@ def fake_palettize(module, nbits, in_ngroups=1, out_ngroups=1):
 
     dtype = module.weight.data.dtype
     device = module.weight.data.device
-    val = module.weight.data.cpu().numpy()
+    val = module.weight.data.cpu().numpy().astype(np.float16)
     
     if out_ngroups == 1 and in_ngroups == 1:
         lut, indices = compress_kmeans(val=val, nbits=nbits)
@@ -159,7 +159,7 @@ def fake_palettize(module, nbits, in_ngroups=1, out_ngroups=1):
     else:
         raise ValueError(f"in_ngroups={in_ngroups} & out_ngroups={out_ngroups} is illegal!!!")
     
-    return torch.from_numpy(val)
+    return torch.from_numpy(val).to(dtype)
 
 
 def restore_weight(module, value):


### PR DESCRIPTION
Hello, 
I ran in a few issues while trying to run the pre-analysis for mixed bit quantization.

### First issue
`ImportError: cannot import name 'get_pipe' from 'python_coreml_stable_diffusion.torch2coreml'`
This was because the used name was `get_pipe` instead of `get_pipeline`.

### Second issue
```
if 'xl' in args.model_version:
               ^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'model_version'
```
This was because the parameter passed to `get_pipeline` was `args.model_version` instead of `args`.

### Third issue
I got an error when trying to change `--default-nbits` because the input was an str by default, but the choices were int.
I fixed it by specifying `type=int `.

### Fourth issue
`RuntimeError: self and mat2 must have the same dtype`
I solved it by changing 
`val = module.weight.data.cpu().numpy().astype(np.float16)`
to
`val = module.weight.data.cpu().numpy()`


I tried to run the code with these fix, and it worked well for me (using Cuda, as my Mac didn't have enough ram for it).

#########

- [ v] I agree to the terms outlined in CONTRIBUTING.md 
