### PR TITLE
Upgrade coremltools, transformers; remove attn workaround

### DIFF
--- a/python_coreml_stable_diffusion/torch2coreml.py
+++ b/python_coreml_stable_diffusion/torch2coreml.py
@@ -309,22 +309,12 @@ def convert_text_encoder(text_encoder, tokenizer, submodule_name, args):
     }
     logger.info(f"Sample inputs spec: {sample_text_encoder_inputs_spec}")
 
-    def _build_causal_attention_mask(self, bsz, seq_len, dtype, device=None):
-        mask = torch.ones((bsz, seq_len, seq_len), dtype=dtype, device=device) * -1e4
-        mask.triu_(1)
-        mask = mask.unsqueeze(1)
-        return mask
-
     class TextEncoder(nn.Module):
 
         def __init__(self, with_hidden_states_for_layer=None):
             super().__init__()
             self.text_encoder = text_encoder
             self.with_hidden_states_for_layer = with_hidden_states_for_layer
-            setattr(
-                self.text_encoder.text_model, "_build_causal_attention_mask",
-                MethodType(_build_causal_attention_mask,
-                           self.text_encoder.text_model))
 
         def forward(self, input_ids):
             if self.with_hidden_states_for_layer is not None:

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ setup(
     long_description_content_type='text/markdown',
     author='Apple Inc.',
     install_requires=[
-        "coremltools>=7.0b1",
+        "coremltools>=7.0b2",
         "diffusers[torch]",
         "torch",
-        "transformers==4.29.2",
+        "transformers>=4.30.0",
         "huggingface-hub",
         "scipy",
         "numpy<1.24",


### PR DESCRIPTION
Transformers 4.30.0 replaced the `_build_causal_attention_mask` method with a _function_ (thus harder to patch) that could not be converted to Core ML because of https://github.com/apple/coremltools/pull/1915. The PR was released as part of coremltools 7.0b2, and therefore we can:

- Upgrade coremltools.
- Unpin transformers, which had been frozen to `4.29.2`. We now require `4.30.0` or better.
- Remove the custom `_build_causal_attention_mask` in the conversion code.

---

Thank you for your interest in contributing to Core ML Stable Diffusion! Please review [CONTRIBUTING.md](../CONTRIBUTING.md) first. If you would like to proceed with making a pull request, please indicate your agreement to the terms outlined in CONTRIBUTING.md by checking the box below. If not, please go ahead and fork this repo and make your updates.

We appreciate your interest in the project!

Do not erase the below when submitting your pull request:
#########

- [x] I agree to the terms outlined in CONTRIBUTING.md 
