### PR TITLE
Fix boundary var issue when chunking model with coremltools 7.0

### DIFF
--- a/python_coreml_stable_diffusion/chunk_mlprogram.py
+++ b/python_coreml_stable_diffusion/chunk_mlprogram.py
@@ -122,12 +122,13 @@ def _get_first_chunk_outputs(block, op_idx):
     boundary_vars = set()
     for i in range(op_idx + 1):
         op = block.operations[i]
-        for var in op.outputs:
-            if var.val is None:  # only consider non const vars
-                for child_op in var.child_ops:
-                    child_op_idx = block.operations.index(child_op)
-                    if child_op_idx > op_idx:
-                        boundary_vars.add(var)
+        if not op.op_type.startswith("const"):
+            for var in op.outputs:
+                if var.val is None:  # only consider non const vars
+                    for child_op in var.child_ops:
+                        child_op_idx = block.operations.index(child_op)
+                        if child_op_idx > op_idx:
+                            boundary_vars.add(var)
     return list(boundary_vars)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-coremltools>=7.0b1
+coremltools>=7.0
 diffusers[torch]
 torch
 transformers==4.29.2


### PR DESCRIPTION
Without this change the following command will fail when using `coremltools` version `7.0`:
```
python -m python_coreml_stable_diffusion.chunk_mlprogram --mlpackage-path <base_unet_mlpackage_path> --check-output-correctness -o <out_path>
```

- [x] I agree to the terms outlined in CONTRIBUTING.md 
