### PR TITLE
Merge dicts with unpacking to support Python 3.8

### DIFF
--- a/python_coreml_stable_diffusion/pipeline.py
+++ b/python_coreml_stable_diffusion/pipeline.py
@@ -517,7 +517,10 @@ class CoreMLStableDiffusionPipeline(DiffusionPipeline):
                 control_net_additional_residuals = {}
 
             # predict the noise residual
-            unet_additional_kwargs = unet_additional_kwargs | control_net_additional_residuals
+            unet_additional_kwargs = {
+                **unet_additional_kwargs,
+                **control_net_additional_residuals,
+            }
 
             noise_pred = self.unet(
                 sample=latent_model_input.astype(np.float16),


### PR DESCRIPTION
This patch fixes the error when running pipeline.py on Python 3.8, which is specified as a requirement in the document.

FYI: https://peps.python.org/pep-0584/

- [x] I agree to the terms outlined in CONTRIBUTING.md 
