### PR TITLE
bugfix: updated scaling factor for SDXL

### DIFF
--- a/python_coreml_stable_diffusion/pipeline.py
+++ b/python_coreml_stable_diffusion/pipeline.py
@@ -311,7 +311,14 @@ class CoreMLStableDiffusionPipeline(DiffusionPipeline):
         return image, has_nsfw_concept
 
     def decode_latents(self, latents):
-        latents = 1 / 0.18215 * latents
+
+        if self.xl:
+            scaling_factor =0.13025
+        else:
+            scaling_factor = 0.18215
+
+        latents = 1 / scaling_factor * latents
+
         dtype = self.vae_decoder.expected_inputs['z']['dtype']
         image = self.vae_decoder(z=latents.astype(dtype))["image"]
         image = np.clip(image / 2 + 0.5, 0, 1)


### PR DESCRIPTION
Updating the scale factor for SDXL. Using the prior scale factor results in hazy images. Updated scale factor is from https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/vae/config.json

with updated scale factor (0.13025):

![_randomSeed_5893757_13-10:09:45_numInferenceSteps25](https://github.com/apple/ml-stable-diffusion/assets/65481379/286a70ef-ab72-4d80-9b2a-7f57f1a10d59)

with prior scale factor (0.18215):

![_randomSeed_5893757_13-10:05:27_numInferenceSteps25](https://github.com/apple/ml-stable-diffusion/assets/65481379/a2e3c9b8-60d3-449d-8115-2992baa09d3c)

Thank you for your interest in contributing to Core ML Stable Diffusion! Please review [CONTRIBUTING.md](../CONTRIBUTING.md) first. If you would like to proceed with making a pull request, please indicate your agreement to the terms outlined in CONTRIBUTING.md by checking the box below. If not, please go ahead and fork this repo and make your updates.

We appreciate your interest in the project!

Do not erase the below when submitting your pull request:
#########

- [ ] I agree to the terms outlined in CONTRIBUTING.md 
