### PR TITLE
Use sRGB if available

### DIFF
--- a/swift/StableDiffusion/pipeline/CGImage+vImage.swift
+++ b/swift/StableDiffusion/pipeline/CGImage+vImage.swift
@@ -58,7 +58,7 @@ extension CGImage {
         let cgImage = uint8Image.makeCGImage(cgImageFormat:
                 .init(bitsPerComponent: 8,
                       bitsPerPixel: 3*8,
-                      colorSpace: CGColorSpace(name: CGColorSpace.sRGB),
+                      colorSpace: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
                       bitmapInfo: bitmapInfo)!)!
 
         return cgImage

--- a/swift/StableDiffusion/pipeline/CGImage+vImage.swift
+++ b/swift/StableDiffusion/pipeline/CGImage+vImage.swift
@@ -58,7 +58,7 @@ extension CGImage {
         let cgImage = uint8Image.makeCGImage(cgImageFormat:
                 .init(bitsPerComponent: 8,
                       bitsPerPixel: 3*8,
-                      colorSpace: CGColorSpaceCreateDeviceRGB(),
+                      colorSpace: CGColorSpace(name: CGColorSpace.sRGB),
                       bitmapInfo: bitmapInfo)!)!
 
         return cgImage


### PR DESCRIPTION
The varying device colorspace is causing consistency issues with generated output. This PR changes the CGImage returned by the generation to use the standard sRGB colorspace (if available, if not it falls back to device).

- [x] I agree to the terms outlined in CONTRIBUTING.md 
