### PR TITLE
Update swift-argument-parser to latest minor version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
             targets: ["StableDiffusionCLI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser.git", exact: "1.2.0")
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.3")
     ],
     targets: [
         .target(


### PR DESCRIPTION
This will also make ml-stable-diffusion more tolerant with regard to which swift-argument-parser version it needs, resulting in fewer version conflicts in Xcode projects.

- [x] I agree to the terms outlined in CONTRIBUTING.md 
