### PR TITLE
fixes sd3-version argument needed for torch2coreml

### DIFF
--- a/python_coreml_stable_diffusion/mixed_bit_compression_pre_analysis.py
+++ b/python_coreml_stable_diffusion/mixed_bit_compression_pre_analysis.py
@@ -578,6 +578,11 @@ if __name__ == "__main__":
          "If specified, the specified VAE will be converted instead of the one associated to the `--model-version` checkpoint. "
          "No precision override is applied when using a custom VAE."
          ))
+    # needed since this calls `torch2coreml` and that would throw an error
+    parser.add_argument(
+        "--sd3-version",
+        action="store_true",
+        help=("If specified, the pre-trained model will be treated as an SD3 model."))
 
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
## Adds fix for `sd3-version` in `mixed_bit_compression_pre_analysis.py`

Adds in the argument as it is needed in `torch2coreml.py` since, it is raises an error on line 1457.
The fix is straightforward
```python
parser.add_argument(
        "--sd3-version",
        action="store_true",
        help=("If specified, the pre-trained model will be treated as an SD3 model."))
```

Thank you!
