### PR TITLE
Refactor the model chunking script to work with all version of coremltools

### DIFF
--- a/python_coreml_stable_diffusion/chunk_mlprogram.py
+++ b/python_coreml_stable_diffusion/chunk_mlprogram.py
@@ -231,7 +231,7 @@ def _make_second_chunk_prog(prog, op_idx):
     return prog
 
 
-def _legancy_model_chunking(args):
+def _legacy_model_chunking(args):
     # TODO: Remove this method after setting the coremltools dependency >= 8.0
     os.makedirs(args.o, exist_ok=True)
 
@@ -344,13 +344,13 @@ def main(args):
 
     if ct_version != "8.0b2" and ct_version < "8.0":
         # With coremltools version <= 8.0b1,
-        # we use the lagancy implementation.
+        # we use the legacy implementation.
         # TODO: Remove the logic after setting the coremltools dependency >= 8.0.
         logger.info(
             f"coremltools version {ct_version} detected. Recommended upgrading the package version to "
             f"'8.0b2' when you running chunk_mlprogram.py script for the latest supports and bug fixes."
         )
-        _legancy_model_chunking(args)
+        _legacy_model_chunking(args)
     else:
         # Starting from coremltools==8.0b2, there is this `bisect_model` API that
         # we can directly call into.

--- a/python_coreml_stable_diffusion/chunk_mlprogram.py
+++ b/python_coreml_stable_diffusion/chunk_mlprogram.py
@@ -355,12 +355,14 @@ def main(args):
         # Starting from coremltools==8.0b2, there is this `bisect_model` API that
         # we can directly call into.
         from coremltools.models.utils import bisect_model
+        logger.info(f"Start chunking model {args.mlpackage_path} into two pieces.")
         ct.models.utils.bisect_model(
             model=args.mlpackage_path,
             output_dir=args.o,
             merge_chunks_to_pipeline=args.merge_chunks_in_pipeline_model,
             check_output_correctness=args.check_output_correctness,
         )
+        logger.info(f"Model chunking is done.")
 
     # Remove original (non-chunked) model if requested
     if args.remove_original:


### PR DESCRIPTION
* In coremltools `8.0b2`, they introduced an util `ct.models.utils.bisect_model` (https://github.com/apple/coremltools/pull/2286),
in which does the same thing as `chunk_mlprogram.py`, with a more robust implementation.
For instance, taking the source CoreML model spec version into account.
* This PR makes the `chunk_mlprogram.py` works on older `coremltools`, like `7.2`, which has been reported a bug (https://github.com/apple/ml-stable-diffusion/issues/333).
* Also for the `coremltools` version `>=8.0b2`, we refactor the script to directly call into `bisect_model` API.
* The legancy implementation should be removed after we officially set the dependency on `coremltools>=8.0`

Testing:
`python -m python_coreml_stable_diffusion.torch2coreml --convert-unet --convert-text-encoder --convert-vae-decoder --convert-safety-checker --model-version CompVis/stable-diffusion-v1-4 -o ../../model_zoo --chunk-unet`
ran on both `coremltools==8.0b2` and `coremltools==7.2`