### PR TITLE
Add diffusionkit to installation dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "invisible-watermark",
         "safetensors",
         "matplotlib",
+        "diffusionkit",
     ],
     packages=find_packages(),
     classifiers=[


### PR DESCRIPTION
Adds diffusionkit to package installation dependency to avoid erroring out when converting UNet.

The code in [`torch2coreml`](https://github.com/apple/ml-stable-diffusion/blob/70cfcce955b9799943f8f99435c03f74c02db1aa/python_coreml_stable_diffusion/torch2coreml.py#L19) has a dependency on `diffusionkit`.
