### PR TITLE
Fix invalid mask implementation

### DIFF
--- a/swift/StableDiffusion/pipeline/TextEncoderT5.swift
+++ b/swift/StableDiffusion/pipeline/TextEncoderT5.swift
@@ -83,23 +83,22 @@ public struct TextEncoderT5: TextEncoderT5Model {
         let bosToken = tokenizer.bosTokenId ?? 0
         let eosToken = tokenizer.eosTokenId ?? 1
         let padToken = bosToken
-        let maskToken = eosToken
+        let maskToken = -Float32.greatestFiniteMagnitude
 
         // Truncate and pad input to the expected length
         let truncatedIds = ids.prefix(inputLength - 1) + [eosToken]
         let inputIds = truncatedIds + Array(repeating: padToken, count: inputLength - truncatedIds.count)
 
         let attentionMaskName = "attention_mask"
-        var attentionMask: [Int] = inputIds.map { token in
-            token == padToken ? maskToken : padToken
+        var attentionMask: [Float32] = inputIds.map { token in
+            token == padToken ? maskToken : 0.0
         }
-        attentionMask[0] = bosToken
+        attentionMask[0] = 0.0
 
         let floatIds = inputIds.map { Float32($0) }
-        let floatMask = attentionMask.map { Float32($0) }
 
         let inputArray = MLShapedArray<Float32>(scalars: floatIds, shape: inputShape)
-        let maskArray = MLShapedArray<Float32>(scalars: floatMask, shape: inputShape)
+        let maskArray = MLShapedArray<Float32>(scalars: attentionMask, shape: inputShape)
         let inputFeatures = try! MLDictionaryFeatureProvider(
             dictionary: [inputName: MLMultiArray(inputArray),
                          attentionMaskName: MLMultiArray(maskArray)])


### PR DESCRIPTION
### Fix masking implementation at TextEncoderT5.

## Issue
- The current implementation uses 1 as the maskToken, which prevents proper masking functionality.
- In theory, masking is done with the smallest number, such as -infinity or minimum value for the type.

## Solution
- Replace the masking value with the smallest representable number for the given data type. This approach aligns with T5 inference code in Python's transformers library.

## Details
- Replace 1 with the smallest representable number (e.g., the minimum value for the Float32).
`let maskToken = -Float32.greatestFiniteMagnitude`
This change ensures that masked tokens are effectively ignored.

## References
- Python's transformers library [https://github.com/huggingface/transformers/blob/0c718f16d1e8b73ac637529f6328fd8cb378ce7e/src/transformers/modeling_utils.py#L1169](url)