### PR TITLE
Fix for Mask Patch Failure and Quantization Issues in Latest `transformers` Versions

### DIFF
--- a/python_coreml_stable_diffusion/torch2coreml.py
+++ b/python_coreml_stable_diffusion/torch2coreml.py
@@ -336,6 +336,7 @@ def patched_make_causal_mask(input_ids_shape, dtype, device, past_key_values_len
     return mask[None, None, :, :].expand(bsz, 1, tgt_len, tgt_len + past_key_values_length)
 
 modeling_clip._make_causal_mask = patched_make_causal_mask
+modeling_clip._create_4d_causal_attention_mask = patched_make_causal_mask
 
 def convert_text_encoder(text_encoder, tokenizer, submodule_name, args):
     """ Converts the text encoder component of Stable Diffusion


### PR DESCRIPTION
In the latest versions of the `transformers` library (specifically version 4.34.1 and above), the `_make_causal_mask` function in the `modeling_clip` module has been removed. Previously, code that utilized this function looked like this:

```python
causal_attention_mask = _make_causal_mask(input_shape, hidden_states.dtype, device=hidden_states.device)
```

However, with recent updates, this call has been replaced by:

```python
causal_attention_mask = _create_4d_causal_attention_mask(input_shape, hidden_states.dtype, device=hidden_states.device)
```
You can see more in this thread huggingface/transformers#28305.

This change disrupts the functionality in `python_coreml_stable_diffusion/torch2coreml.py`, where the following line:

```python
modeling_clip._make_causal_mask = patched_make_causal_mask
```

can no longer patch the `_make_causal_mask` function as expected, resulting in the following error during quantization:

```
ValueError: Input X contains infinity or a value too large for dtype('float64').
```

See related issues: #331, #303, #325, #246

This PR addresses the issue by adding a monkey patch to `modeling_clip` for the `_create_4d_causal_attention_mask` function, thereby fixing the mask patch failure and restoring compatibility with the `--quantize-nbits` feature in the latest `transformers` versions. It also retains the original function override to maintain support for older `transformers` versions.