### PR TITLE
refactor: update swift-transformers to 0.1.14 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.3"),
-        .package(url: "https://github.com/huggingface/swift-transformers.git", exact: "0.1.8"),
+        .package(url: "https://github.com/huggingface/swift-transformers.git", exact: "0.1.14"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
             targets: ["StableDiffusionCLI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.3"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
         .package(url: "https://github.com/huggingface/swift-transformers.git", exact: "0.1.14"),
     ],
     targets: [

--- a/swift/StableDiffusion/tokenizer/T5Tokenizer.swift
+++ b/swift/StableDiffusion/tokenizer/T5Tokenizer.swift
@@ -9,11 +9,11 @@ import Tokenizers
 public extension Config {
     /// Assumes the file is already present at local url.
     /// `fileURL` is a complete local file path for the given model
-    public init(fileURL: URL) throws  {
+    init(fileURL: URL) throws  {
         let data = try Data(contentsOf: fileURL)
         let parsed = try JSONSerialization.jsonObject(with: data, options: [])
-        guard var dictionary = parsed as? [String: Any] else { throw Hub.HubClientError.parse }
-        
+        guard var dictionary = parsed as? [NSString: Any] else { throw Hub.HubClientError.parse }
+
         // Necessary override for loading local tokenizer configs
         dictionary["tokenizer_class"] = "T5Tokenizer"
         self.init(dictionary)


### PR DESCRIPTION
# Update Dependencies and Fix Tokenizer Initialization Logic

## Description
This pull request introduces the following changes:

1. **`Package.swift`**:
   - Updated the dependency for `swift-transformers` from version `0.1.8` to `0.1.14`.

2. **`T5Tokenizer.swift`**:
   - Removed the redundant `public` modifier from the `init` method.
   - Adjusted the type for the parsed dictionary from `[String: Any]` to `[NSString: Any]` to ensure compatibility during JSON deserialization.

## Reason for Changes
- The `swift-transformers` dependency update aligns the project with the latest improvements and bug fixes.
- Adjusting the dictionary type ensures proper parsing and avoids potential runtime errors when dealing with tokenizer configurations.

## Testing
- Verified successful compilation after dependency updates.
- Tested the initialization logic with local tokenizer configurations to confirm proper functionality.